### PR TITLE
Add quarterly idle-balance email cron

### DIFF
--- a/pages/api/email-idle-balances.ts
+++ b/pages/api/email-idle-balances.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server'
+import { createAdminClient } from '@/db/edge'
+import { isProd } from '@/db/env'
+import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
+import { computeIdleBalances } from '@/utils/idle-balances'
+
+export const config = {
+  runtime: 'edge',
+  regions: ['sfo1'],
+}
+
+// Quarterly nudge (see vercel.json) to holders of long-idle withdrawable balances,
+// so the money isn't forgotten. Recomputed each run; summary goes to Austin.
+const MONTHS = 12
+const THRESHOLD = 10_000
+const SUMMARY_EMAIL = 'austin@manifund.org'
+
+export default async function handler() {
+  if (!isProd()) {
+    return NextResponse.json('not prod')
+  }
+  const supabase = createAdminClient()
+  const idle = await computeIdleBalances(supabase, MONTHS, THRESHOLD)
+
+  for (const holder of idle) {
+    const amount = Math.floor(holder.aged)
+    await sendTemplateEmail(
+      TEMPLATE_IDS.GENERIC_NOTIF,
+      {
+        notifText: `You're receiving this email because you've had a withdrawable balance of $${amount.toLocaleString(
+          'en-US'
+        )} on Manifund for at least a year. Of course, you're welcome to leave it on the platform, but just flagging to make sure the money hasn't been forgotten. Thank you!`,
+        buttonUrl: `https://manifund.org/${holder.username}`,
+        buttonText: 'View your balance',
+        subject: 'Your Manifund balance',
+      },
+      holder.userId
+    )
+  }
+
+  const summary = idle
+    .map((h) => `${h.full_name} (@${h.username}): $${Math.floor(h.aged).toLocaleString('en-US')}`)
+    .join('; ')
+  await sendTemplateEmail(
+    TEMPLATE_IDS.GENERIC_NOTIF,
+    {
+      notifText: idle.length
+        ? `Quarterly idle-balance emails sent to ${idle.length} ${
+            idle.length === 1 ? 'person' : 'people'
+          } with a withdrawable balance of $${THRESHOLD.toLocaleString(
+            'en-US'
+          )}+ held for ${MONTHS}+ months: ${summary}`
+        : `Quarterly idle-balance check ran: no one currently holds a withdrawable balance of $${THRESHOLD.toLocaleString(
+            'en-US'
+          )}+ for ${MONTHS}+ months, so no emails were sent.`,
+      buttonUrl: 'https://manifund.org',
+      buttonText: 'Manifund',
+      subject: `Idle balance emails sent: ${idle.length}`,
+    },
+    undefined,
+    SUMMARY_EMAIL
+  )
+
+  return NextResponse.json({ emailed: idle.length })
+}

--- a/pages/api/email-idle-balances.ts
+++ b/pages/api/email-idle-balances.ts
@@ -12,7 +12,7 @@ export const config = {
 // Quarterly nudge (see vercel.json) to holders of long-idle withdrawable balances,
 // so the money isn't forgotten. Recomputed each run; summary goes to Austin.
 const MONTHS = 12
-const THRESHOLD = 10_000
+const THRESHOLD = 5_000
 const SUMMARY_EMAIL = 'austin@manifund.org'
 
 export default async function handler() {

--- a/pages/api/email-idle-balances.ts
+++ b/pages/api/email-idle-balances.ts
@@ -10,10 +10,10 @@ export const config = {
 }
 
 // Quarterly nudge (see vercel.json) to holders of long-idle withdrawable balances,
-// so the money isn't forgotten. Recomputed each run; summary goes to Austin.
+// so the money isn't forgotten. Recomputed each run; summary goes to the team.
 const MONTHS = 12
 const THRESHOLD = 5_000
-const SUMMARY_EMAIL = 'austin@manifund.org'
+const SUMMARY_EMAILS = ['austin@manifund.org', 'carol@manifund.org']
 
 export default async function handler() {
   if (!isProd()) {
@@ -41,25 +41,27 @@ export default async function handler() {
   const summary = idle
     .map((h) => `${h.full_name} (@${h.username}): $${Math.floor(h.aged).toLocaleString('en-US')}`)
     .join('; ')
-  await sendTemplateEmail(
-    TEMPLATE_IDS.GENERIC_NOTIF,
-    {
-      notifText: idle.length
-        ? `Quarterly idle-balance emails sent to ${idle.length} ${
-            idle.length === 1 ? 'person' : 'people'
-          } with a withdrawable balance of $${THRESHOLD.toLocaleString(
-            'en-US'
-          )}+ held for ${MONTHS}+ months: ${summary}`
-        : `Quarterly idle-balance check ran: no one currently holds a withdrawable balance of $${THRESHOLD.toLocaleString(
-            'en-US'
-          )}+ for ${MONTHS}+ months, so no emails were sent.`,
-      buttonUrl: 'https://manifund.org',
-      buttonText: 'Manifund',
-      subject: `Idle balance emails sent: ${idle.length}`,
-    },
-    undefined,
-    SUMMARY_EMAIL
-  )
+  for (const summaryEmail of SUMMARY_EMAILS) {
+    await sendTemplateEmail(
+      TEMPLATE_IDS.GENERIC_NOTIF,
+      {
+        notifText: idle.length
+          ? `Quarterly idle-balance emails sent to ${idle.length} ${
+              idle.length === 1 ? 'person' : 'people'
+            } with a withdrawable balance of $${THRESHOLD.toLocaleString(
+              'en-US'
+            )}+ held for ${MONTHS}+ months: ${summary}`
+          : `Quarterly idle-balance check ran: no one currently holds a withdrawable balance of $${THRESHOLD.toLocaleString(
+              'en-US'
+            )}+ for ${MONTHS}+ months, so no emails were sent.`,
+        buttonUrl: 'https://manifund.org',
+        buttonText: 'Manifund',
+        subject: `Idle balance emails sent: ${idle.length}`,
+      },
+      undefined,
+      summaryEmail
+    )
+  }
 
   return NextResponse.json({ emailed: idle.length })
 }

--- a/scripts/idle-cash-balances.ts
+++ b/scripts/idle-cash-balances.ts
@@ -1,200 +1,30 @@
 import { createAdminClient } from '@/db/edge'
+import { computeIdleBalances } from '@/utils/idle-balances'
 
-// "Withdrawable balance" = calculateCashBalance (utils/math.ts): sum of
-// txn.amount * getTxnCashMultiplier(...) plus pending-bid locks. This distinguishes
-// withdrawable cash from charity-only funds (unaccredited deposits, cash->charity, etc).
-// "Aged N months" = the running withdrawable balance never dropped below that amount at
-// any point in the trailing N months, i.e. min(balance over window) is the portion that
-// has been sitting untouched for the whole window.
+// Prints holders of long-idle withdrawable balances. Computation lives in
+// utils/idle-balances.ts (shared with the quarterly /api/email-idle-balances cron).
 //
-// Usage: bun run scripts/idle-cash-balances.ts [months] [threshold]
+// Usage: bun run scripts/idle-cash-balances.ts [months] [threshold] [as-of-date]
+//   e.g. bun run scripts/idle-cash-balances.ts 12 10000 2026-07-31
 
 const MONTHS = Number(process.argv[2] ?? 6)
 const THRESHOLD = Number(process.argv[3] ?? 10_000)
-const NOW = new Date('2026-07-31T00:00:00.000Z')
-const WINDOW_START = new Date(
-  Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() - MONTHS, NOW.getUTCDate())
-).toISOString()
-const IGNORE_ACCREDITATION_DATE = new Date('2023-11-02')
-const CHARITABLE_DEPOSITS = new Set([
-  '1e17c09d-aa7f-432a-b523-89691531b304',
-  'c223e240-598f-41a9-8aa0-7a961d8db258',
-])
+const NOW = process.argv[4] ? new Date(`${process.argv[4]}T00:00:00.000Z`) : new Date()
 
-type Txn = {
-  id: string
-  amount: number
-  created_at: string
-  from_id: string | null
-  to_id: string
-  token: string
-  type: string | null
-  project: string | null
-}
-
-// Faithful port of getTxnCashMultiplier (utils/math.ts:270-311).
-function getTxnCashMultiplier(
-  txn: Txn,
-  userId: string,
-  projectCreator: string | null,
-  accredited: boolean
-) {
-  if (
-    txn.token !== 'USD' ||
-    (txn.from_id !== userId && txn.to_id !== userId) ||
-    txn.type === 'profile donation' ||
-    txn.type === 'tip' ||
-    txn.type === 'return bank funds'
-  ) {
-    return 0
-  }
-  const isIncoming = txn.to_id === userId
-  const isOwnProject = projectCreator === userId
-  const actuallyAccredited = new Date(txn.created_at) < IGNORE_ACCREDITATION_DATE && accredited
-  if (txn.type === 'cash to charity transfer') return -1
-  if (isIncoming && txn.from_id === userId) return isOwnProject ? 1 : 0
-  if (txn.type === 'project donation') return isIncoming ? 1 : 0
-  if (txn.type === 'user to amm trade' || txn.type === 'user to user trade') {
-    if (isOwnProject || actuallyAccredited) return isIncoming ? 1 : -1
-    return 0
-  }
-  if (txn.type === 'inject amm liquidity') return isOwnProject ? (isIncoming ? 1 : -1) : 0
-  if (txn.type === 'deposit') return actuallyAccredited && !CHARITABLE_DEPOSITS.has(txn.id) ? 1 : 0
-  if (txn.type === 'withdraw') return -1
-  return 0
-}
-
-async function pageAll<T>(query: (from: number, to: number) => any): Promise<T[]> {
-  const out: T[] = []
-  const PAGE = 1000
-  for (let offset = 0; ; offset += PAGE) {
-    const { data } = await query(offset, offset + PAGE - 1).throwOnError()
-    out.push(...((data ?? []) as T[]))
-    if (!data || data.length < PAGE) break
-  }
-  return out
-}
+const fmt = (n: number) =>
+  '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 
 async function main() {
   const supabase = createAdminClient()
+  const qualifying = await computeIdleBalances(supabase, MONTHS, THRESHOLD, NOW)
 
-  // Project -> creator (for isOwnProject).
-  const projects = await pageAll<{ id: string; creator: string }>((f, t) =>
-    supabase.from('projects').select('id, creator').range(f, t)
+  const windowStart = new Date(
+    Date.UTC(NOW.getUTCFullYear(), NOW.getUTCMonth() - MONTHS, NOW.getUTCDate())
   )
-  const creatorByProject = new Map(projects.map((p) => [p.id, p.creator]))
-  console.log(`Fetched ${projects.length} projects`)
-
-  // All USD txns.
-  const txns = await pageAll<Txn>((f, t) =>
-    supabase
-      .from('txns')
-      .select('id, amount, created_at, from_id, to_id, token, type, project')
-      .eq('token', 'USD')
-      .order('created_at', { ascending: true })
-      .range(f, t)
-  )
-  console.log(`Fetched ${txns.length} USD txns`)
-
-  // Accreditation status for every user who appears in a txn.
-  const userIds = new Set<string>()
-  for (const t of txns) {
-    if (t.to_id) userIds.add(t.to_id)
-    if (t.from_id) userIds.add(t.from_id)
-  }
-  const accreditedById = new Map<string, boolean>()
-  const idList = Array.from(userIds)
-  for (let i = 0; i < idList.length; i += 500) {
-    const { data } = await supabase
-      .from('profiles')
-      .select('id, accreditation_status')
-      .in('id', idList.slice(i, i + 500))
-      .throwOnError()
-    for (const p of data ?? []) accreditedById.set(p.id, !!p.accreditation_status)
-  }
-
-  // Pending bids -> per-user withdrawable lock (getBidCashMultiplier: -1 for a
-  // pending buy/donate bid on the bidder's OWN non-hidden project).
-  const bids = await pageAll<{
-    amount: number
-    status: string
-    type: string
-    bidder: string
-    projects: { creator: string; stage: string } | null
-  }>((f, t) =>
-    supabase
-      .from('bids')
-      .select('amount, status, type, bidder, projects(creator, stage)')
-      .eq('status', 'pending')
-      .range(f, t)
-  )
-  const bidLockByUser = new Map<string, number>()
-  for (const b of bids) {
-    if (!b.projects) continue
-    const projectIsBidders = b.projects.creator === b.bidder
-    if (
-      b.type === 'sell' ||
-      b.type === 'assurance sell' ||
-      b.projects.stage === 'hidden' ||
-      !projectIsBidders
-    )
-      continue
-    bidLockByUser.set(b.bidder, (bidLockByUser.get(b.bidder) ?? 0) - b.amount)
-  }
-
-  // Per-user signed withdrawable deltas, chronological.
-  const deltasByUser = new Map<string, { created_at: string; delta: number }[]>()
-  const push = (userId: string, created_at: string, delta: number) => {
-    if (delta === 0) return
-    if (!deltasByUser.has(userId)) deltasByUser.set(userId, [])
-    deltasByUser.get(userId)!.push({ created_at, delta })
-  }
-  for (const t of txns) {
-    const creator = t.project ? (creatorByProject.get(t.project) ?? null) : null
-    for (const uid of new Set([t.to_id, t.from_id].filter(Boolean) as string[])) {
-      const m = getTxnCashMultiplier(t, uid, creator, accreditedById.get(uid) ?? false)
-      if (m !== 0) push(uid, t.created_at, t.amount * m)
-    }
-  }
-
-  const qualifying: { userId: string; current: number; aged: number }[] = []
-  for (const [userId, deltas] of deltasByUser) {
-    deltas.sort((a, b) => a.created_at.localeCompare(b.created_at))
-    let bal = 0
-    let i = 0
-    for (; i < deltas.length && deltas[i].created_at < WINDOW_START; i++) bal += deltas[i].delta
-    let aged = bal
-    for (; i < deltas.length; i++) {
-      bal += deltas[i].delta
-      if (bal < aged) aged = bal
-    }
-    // Current withdrawable includes pending-bid locks (matches calculateCashBalance).
-    const current = bal + (bidLockByUser.get(userId) ?? 0)
-    // Pending-bid locks eat into the aged portion too.
-    aged = Math.min(aged, current)
-    if (aged >= THRESHOLD) {
-      qualifying.push({ userId, current, aged })
-    }
-  }
-
-  qualifying.sort((a, b) => b.aged - a.aged)
-
-  const nameById = new Map<string, { full_name: string; username: string }>()
-  const qIds = qualifying.map((q) => q.userId)
-  for (let i = 0; i < qIds.length; i += 500) {
-    const { data } = await supabase
-      .from('profiles')
-      .select('id, full_name, username')
-      .in('id', qIds.slice(i, i + 500))
-      .throwOnError()
-    for (const p of data ?? []) nameById.set(p.id, p as any)
-  }
-
-  const fmt = (n: number) =>
-    '$' + n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-
   console.log(
-    `\n${qualifying.length} people held >= $${THRESHOLD.toLocaleString()} withdrawable continuously since ${WINDOW_START.slice(0, 10)} (${MONTHS} months):\n`
+    `\n${qualifying.length} people held >= $${THRESHOLD.toLocaleString()} withdrawable continuously since ${windowStart
+      .toISOString()
+      .slice(0, 10)} (${MONTHS} months):\n`
   )
   console.log(
     'Name'.padEnd(30),
@@ -204,12 +34,11 @@ async function main() {
   )
   console.log('-'.repeat(82))
   for (const q of qualifying) {
-    const p = nameById.get(q.userId)
     console.log(
-      (p?.full_name ?? 'Unknown').slice(0, 29).padEnd(30),
+      q.full_name.slice(0, 29).padEnd(30),
       fmt(q.aged).padStart(15),
       fmt(q.current).padStart(16),
-      '  @' + (p?.username ?? q.userId)
+      '  @' + q.username
     )
   }
   const totalAged = qualifying.reduce((s, q) => s + q.aged, 0)

--- a/utils/idle-balances.ts
+++ b/utils/idle-balances.ts
@@ -1,0 +1,205 @@
+import { SupabaseClient } from '@supabase/supabase-js'
+
+// "Withdrawable balance" = calculateCashBalance (utils/math.ts): sum of
+// txn.amount * getTxnCashMultiplier(...) plus pending-bid locks. This distinguishes
+// withdrawable cash from charity-only funds (unaccredited deposits, cash->charity, etc).
+// "Aged N months" = the running withdrawable balance never dropped below that amount at
+// any point in the trailing N months, i.e. min(balance over window) is the portion that
+// has been sitting untouched for the whole window.
+
+const IGNORE_ACCREDITATION_DATE = new Date('2023-11-02')
+const CHARITABLE_DEPOSITS = new Set([
+  '1e17c09d-aa7f-432a-b523-89691531b304',
+  'c223e240-598f-41a9-8aa0-7a961d8db258',
+])
+
+type Txn = {
+  id: string
+  amount: number
+  created_at: string
+  from_id: string | null
+  to_id: string
+  token: string
+  type: string | null
+  project: string | null
+}
+
+export type IdleBalance = {
+  userId: string
+  username: string
+  full_name: string
+  current: number
+  aged: number
+}
+
+// Faithful port of getTxnCashMultiplier (utils/math.ts:270-311).
+function getTxnCashMultiplier(
+  txn: Txn,
+  userId: string,
+  projectCreator: string | null,
+  accredited: boolean
+) {
+  if (
+    txn.token !== 'USD' ||
+    (txn.from_id !== userId && txn.to_id !== userId) ||
+    txn.type === 'profile donation' ||
+    txn.type === 'tip' ||
+    txn.type === 'return bank funds'
+  ) {
+    return 0
+  }
+  const isIncoming = txn.to_id === userId
+  const isOwnProject = projectCreator === userId
+  const actuallyAccredited = new Date(txn.created_at) < IGNORE_ACCREDITATION_DATE && accredited
+  if (txn.type === 'cash to charity transfer') return -1
+  if (isIncoming && txn.from_id === userId) return isOwnProject ? 1 : 0
+  if (txn.type === 'project donation') return isIncoming ? 1 : 0
+  if (txn.type === 'user to amm trade' || txn.type === 'user to user trade') {
+    if (isOwnProject || actuallyAccredited) return isIncoming ? 1 : -1
+    return 0
+  }
+  if (txn.type === 'inject amm liquidity') return isOwnProject ? (isIncoming ? 1 : -1) : 0
+  if (txn.type === 'deposit') return actuallyAccredited && !CHARITABLE_DEPOSITS.has(txn.id) ? 1 : 0
+  if (txn.type === 'withdraw') return -1
+  return 0
+}
+
+async function pageAll<T>(query: (from: number, to: number) => any): Promise<T[]> {
+  const out: T[] = []
+  const PAGE = 1000
+  for (let offset = 0; ; offset += PAGE) {
+    const { data } = await query(offset, offset + PAGE - 1).throwOnError()
+    out.push(...((data ?? []) as T[]))
+    if (!data || data.length < PAGE) break
+  }
+  return out
+}
+
+// Everyone whose withdrawable balance stayed >= threshold for the whole trailing
+// window of `months` months (as of `now`), sorted by aged amount descending.
+export async function computeIdleBalances(
+  supabase: SupabaseClient,
+  months: number,
+  threshold: number,
+  now: Date = new Date()
+): Promise<IdleBalance[]> {
+  const windowStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - months, now.getUTCDate())
+  ).toISOString()
+
+  // Project -> creator (for isOwnProject).
+  const projects = await pageAll<{ id: string; creator: string }>((f, t) =>
+    supabase.from('projects').select('id, creator').range(f, t)
+  )
+  const creatorByProject = new Map(projects.map((p) => [p.id, p.creator]))
+
+  // All USD txns.
+  const txns = await pageAll<Txn>((f, t) =>
+    supabase
+      .from('txns')
+      .select('id, amount, created_at, from_id, to_id, token, type, project')
+      .eq('token', 'USD')
+      .order('created_at', { ascending: true })
+      .range(f, t)
+  )
+
+  // Accreditation status for every user who appears in a txn.
+  const userIds = new Set<string>()
+  for (const t of txns) {
+    if (t.to_id) userIds.add(t.to_id)
+    if (t.from_id) userIds.add(t.from_id)
+  }
+  const accreditedById = new Map<string, boolean>()
+  const idList = Array.from(userIds)
+  for (let i = 0; i < idList.length; i += 500) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, accreditation_status')
+      .in('id', idList.slice(i, i + 500))
+      .throwOnError()
+    for (const p of data ?? []) accreditedById.set(p.id, !!p.accreditation_status)
+  }
+
+  // Pending bids -> per-user withdrawable lock (getBidCashMultiplier: -1 for a
+  // pending buy/donate bid on the bidder's OWN non-hidden project).
+  const bids = await pageAll<{
+    amount: number
+    status: string
+    type: string
+    bidder: string
+    projects: { creator: string; stage: string } | null
+  }>((f, t) =>
+    supabase
+      .from('bids')
+      .select('amount, status, type, bidder, projects(creator, stage)')
+      .eq('status', 'pending')
+      .range(f, t)
+  )
+  const bidLockByUser = new Map<string, number>()
+  for (const b of bids) {
+    if (!b.projects) continue
+    const projectIsBidders = b.projects.creator === b.bidder
+    if (
+      b.type === 'sell' ||
+      b.type === 'assurance sell' ||
+      b.projects.stage === 'hidden' ||
+      !projectIsBidders
+    )
+      continue
+    bidLockByUser.set(b.bidder, (bidLockByUser.get(b.bidder) ?? 0) - b.amount)
+  }
+
+  // Per-user signed withdrawable deltas, chronological.
+  const deltasByUser = new Map<string, { created_at: string; delta: number }[]>()
+  const push = (userId: string, created_at: string, delta: number) => {
+    if (delta === 0) return
+    if (!deltasByUser.has(userId)) deltasByUser.set(userId, [])
+    deltasByUser.get(userId)!.push({ created_at, delta })
+  }
+  for (const t of txns) {
+    const creator = t.project ? (creatorByProject.get(t.project) ?? null) : null
+    for (const uid of new Set([t.to_id, t.from_id].filter(Boolean) as string[])) {
+      const m = getTxnCashMultiplier(t, uid, creator, accreditedById.get(uid) ?? false)
+      if (m !== 0) push(uid, t.created_at, t.amount * m)
+    }
+  }
+
+  const qualifying: { userId: string; current: number; aged: number }[] = []
+  for (const [userId, deltas] of deltasByUser) {
+    deltas.sort((a, b) => a.created_at.localeCompare(b.created_at))
+    let bal = 0
+    let i = 0
+    for (; i < deltas.length && deltas[i].created_at < windowStart; i++) bal += deltas[i].delta
+    let aged = bal
+    for (; i < deltas.length; i++) {
+      bal += deltas[i].delta
+      if (bal < aged) aged = bal
+    }
+    // Current withdrawable includes pending-bid locks (matches calculateCashBalance).
+    const current = bal + (bidLockByUser.get(userId) ?? 0)
+    // Pending-bid locks eat into the aged portion too.
+    aged = Math.min(aged, current)
+    if (aged >= threshold) {
+      qualifying.push({ userId, current, aged })
+    }
+  }
+
+  qualifying.sort((a, b) => b.aged - a.aged)
+
+  const nameById = new Map<string, { full_name: string; username: string }>()
+  const qIds = qualifying.map((q) => q.userId)
+  for (let i = 0; i < qIds.length; i += 500) {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, full_name, username')
+      .in('id', qIds.slice(i, i + 500))
+      .throwOnError()
+    for (const p of data ?? []) nameById.set(p.id, p as any)
+  }
+
+  return qualifying.map((q) => ({
+    ...q,
+    username: nameById.get(q.userId)?.username ?? q.userId,
+    full_name: nameById.get(q.userId)?.full_name ?? 'Unknown',
+  }))
+}

--- a/utils/idle-balances.ts
+++ b/utils/idle-balances.ts
@@ -1,4 +1,5 @@
 import { SupabaseClient } from '@supabase/supabase-js'
+import { getBidCashMultiplier, getTxnCashMultiplierRaw } from './math'
 
 // "Withdrawable balance" = calculateCashBalance (utils/math.ts): sum of
 // txn.amount * getTxnCashMultiplier(...) plus pending-bid locks. This distinguishes
@@ -6,12 +7,6 @@ import { SupabaseClient } from '@supabase/supabase-js'
 // "Aged N months" = the running withdrawable balance never dropped below that amount at
 // any point in the trailing N months, i.e. min(balance over window) is the portion that
 // has been sitting untouched for the whole window.
-
-const IGNORE_ACCREDITATION_DATE = new Date('2023-11-02')
-const CHARITABLE_DEPOSITS = new Set([
-  '1e17c09d-aa7f-432a-b523-89691531b304',
-  'c223e240-598f-41a9-8aa0-7a961d8db258',
-])
 
 type Txn = {
   id: string
@@ -30,38 +25,6 @@ export type IdleBalance = {
   full_name: string
   current: number
   aged: number
-}
-
-// Faithful port of getTxnCashMultiplier (utils/math.ts:270-311).
-function getTxnCashMultiplier(
-  txn: Txn,
-  userId: string,
-  projectCreator: string | null,
-  accredited: boolean
-) {
-  if (
-    txn.token !== 'USD' ||
-    (txn.from_id !== userId && txn.to_id !== userId) ||
-    txn.type === 'profile donation' ||
-    txn.type === 'tip' ||
-    txn.type === 'return bank funds'
-  ) {
-    return 0
-  }
-  const isIncoming = txn.to_id === userId
-  const isOwnProject = projectCreator === userId
-  const actuallyAccredited = new Date(txn.created_at) < IGNORE_ACCREDITATION_DATE && accredited
-  if (txn.type === 'cash to charity transfer') return -1
-  if (isIncoming && txn.from_id === userId) return isOwnProject ? 1 : 0
-  if (txn.type === 'project donation') return isIncoming ? 1 : 0
-  if (txn.type === 'user to amm trade' || txn.type === 'user to user trade') {
-    if (isOwnProject || actuallyAccredited) return isIncoming ? 1 : -1
-    return 0
-  }
-  if (txn.type === 'inject amm liquidity') return isOwnProject ? (isIncoming ? 1 : -1) : 0
-  if (txn.type === 'deposit') return actuallyAccredited && !CHARITABLE_DEPOSITS.has(txn.id) ? 1 : 0
-  if (txn.type === 'withdraw') return -1
-  return 0
 }
 
 async function pageAll<T>(query: (from: number, to: number) => any): Promise<T[]> {
@@ -120,8 +83,7 @@ export async function computeIdleBalances(
     for (const p of data ?? []) accreditedById.set(p.id, !!p.accreditation_status)
   }
 
-  // Pending bids -> per-user withdrawable lock (getBidCashMultiplier: -1 for a
-  // pending buy/donate bid on the bidder's OWN non-hidden project).
+  // Pending bids -> per-user withdrawable lock.
   const bids = await pageAll<{
     amount: number
     status: string
@@ -138,15 +100,8 @@ export async function computeIdleBalances(
   const bidLockByUser = new Map<string, number>()
   for (const b of bids) {
     if (!b.projects) continue
-    const projectIsBidders = b.projects.creator === b.bidder
-    if (
-      b.type === 'sell' ||
-      b.type === 'assurance sell' ||
-      b.projects.stage === 'hidden' ||
-      !projectIsBidders
-    )
-      continue
-    bidLockByUser.set(b.bidder, (bidLockByUser.get(b.bidder) ?? 0) - b.amount)
+    const m = getBidCashMultiplier({ ...b, projects: b.projects })
+    if (m !== 0) bidLockByUser.set(b.bidder, (bidLockByUser.get(b.bidder) ?? 0) + b.amount * m)
   }
 
   // Per-user signed withdrawable deltas, chronological.
@@ -159,7 +114,7 @@ export async function computeIdleBalances(
   for (const t of txns) {
     const creator = t.project ? (creatorByProject.get(t.project) ?? null) : null
     for (const uid of new Set([t.to_id, t.from_id].filter(Boolean) as string[])) {
-      const m = getTxnCashMultiplier(t, uid, creator, accreditedById.get(uid) ?? false)
+      const m = getTxnCashMultiplierRaw(t, uid, creator, accreditedById.get(uid) ?? false)
       if (m !== 0) push(uid, t.created_at, t.amount * m)
     }
   }

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -211,7 +211,12 @@ function getBidCharityMultiplier(bid: BidAndProject) {
   }
 }
 
-function getBidCashMultiplier(bid: BidAndProject) {
+export function getBidCashMultiplier(bid: {
+  status: string
+  type: string
+  bidder: string
+  projects: { creator: string; stage: string }
+}) {
   const projectIsBidders = bid.projects.creator === bid.bidder
   if (
     bid.status !== 'pending' ||
@@ -268,6 +273,24 @@ export function getTxnCharityMultiplier(txn: TxnAndProject, userId: string, accr
 }
 
 export function getTxnCashMultiplier(txn: FullTxn, userId: string, accredited: boolean) {
+  return getTxnCashMultiplierRaw(txn, userId, txn.projects?.creator ?? null, accredited)
+}
+
+// Same rules as getTxnCashMultiplier, for callers without a joined projects row
+// (e.g. utils/idle-balances.ts, which pages over every USD txn).
+export function getTxnCashMultiplierRaw(
+  txn: {
+    id: string
+    token: string
+    type: string | null
+    created_at: string
+    from_id: string | null
+    to_id: string
+  },
+  userId: string,
+  projectCreator: string | null,
+  accredited: boolean
+) {
   if (
     txn.token !== 'USD' ||
     (txn.from_id !== userId && txn.to_id !== userId) ||
@@ -278,9 +301,9 @@ export function getTxnCashMultiplier(txn: FullTxn, userId: string, accredited: b
     return 0
   }
   const isIncoming = txn.to_id === userId
-  const isOwnProject = txn.projects?.creator === userId
+  const isOwnProject = projectCreator === userId
   const actuallyAccredited =
-    isBefore(new Date(txn.created_at), new Date('2023-11-02')) && accredited
+    isBefore(new Date(txn.created_at), IGNORE_ACCREDITATION_DATE) && accredited
   if (txn.type === 'cash to charity transfer') {
     return -1
   }

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,10 @@
     {
       "path": "/api/weekly-digest",
       "schedule": "0 17 * * 1"
+    },
+    {
+      "path": "/api/email-idle-balances",
+      "schedule": "0 0 1 2,5,8,11 *"
     }
   ]
 }


### PR DESCRIPTION
Created a Vercel cron job to email users with idle balances every 3 months. If:
- balance is withdrawable and over $5k
- this has been the case for at least the past 12 months
it emails the users and then also sends an email report to Austin and Carol of who was emailed.

It runs quarterly starting November 1.

The diff is large because computation moved from scripts/idle-cash-balances.ts into utils/idle-balances.ts, shared by both. It also changes a couple of functions in utils/math.ts so they can be imported in utils/idle-balances.ts.