### PR TITLE
Refresh AI Safety Funder Bulletin (Aug 18, 2026)

### DIFF
--- a/app/ais-funder-bulletin/page.tsx
+++ b/app/ais-funder-bulletin/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
   description: 'A digest of funders in the AI safety space.',
 }
 
-const LAST_UPDATED = 'July 28, 2026'
+const LAST_UPDATED = 'August 18, 2026'
 
 const LINK = 'text-orange-600 underline decoration-orange-500 decoration-dotted underline-offset-2'
 
@@ -108,7 +108,7 @@ const AT_A_GLANCE: Row[] = [
     expected2026: { v: '$20M', n: 14 },
     fte: '2',
     generalApps: false,
-    openRfps: true,
+    openRfps: false,
     donations: false,
   },
   {
@@ -144,11 +144,11 @@ const AT_A_GLANCE: Row[] = [
     donations: false,
   },
   {
-    name: 'LTFF',
-    href: 'https://funds.effectivealtruism.org/funds/far-future',
+    name: 'Transformative AI Fund',
+    href: 'https://funds.effectivealtruism.org/funds/transformative-ai',
     donated2025: { v: '—' },
     grants2025: { v: '—' },
-    expected2026: { v: '$3M', n: 20 },
+    expected2026: { v: '$4M', n: 20 },
     fte: '1',
     generalApps: true,
     openRfps: false,
@@ -327,12 +327,20 @@ const NOTES: { node: React.ReactNode; text: string }[] = [
     ),
   },
   {
-    text: "Past payouts have been higher, but they haven't posted a payout report in a long time, and they are in a transitional period.",
+    text: 'EA Funds announced in August 2026 that it is closing the LTFF and spending down its remaining balance (~$3.7M) — roughly three-quarters to existing longtermist applications, largely via the first Lightcone Commons round, and ~$0.9M to seed the successor Transformative AI Fund, which launched with a ~$1M seed and hopes to raise more.',
     node: (
       <>
-        <A href="https://funds.effectivealtruism.org/funds/far-future">Past payouts</A>&nbsp;have
-        been higher, but they haven&apos;t posted a payout report in a long time, and they are in a
-        transitional period.
+        EA Funds{' '}
+        <A href="https://forum.effectivealtruism.org/posts/dtZ9wbKWjtvGWDRJx/closing-the-ltff-spending-down-funds-and-a-new-ai-fund-at-ea">
+          announced in August 2026
+        </A>{' '}
+        that it is closing the LTFF and spending down its remaining balance (~$3.7M) — roughly
+        three-quarters to existing longtermist applications, largely via the first Lightcone Commons
+        round, and ~$0.9M to seed the successor Transformative AI Fund, which{' '}
+        <A href="https://forum.effectivealtruism.org/posts/dYuNi5Rh68o9YKstg/ea-funds-is-launching-the-transformative-ai-fund">
+          launched
+        </A>{' '}
+        with a ~$1M seed and hopes to raise more.
       </>
     ),
   },
@@ -490,10 +498,11 @@ export default function AisFunderBulletinPage() {
                   Background:
                   <ul>
                     <li>
-                      Previously Open Philanthropy, it grew out of a partnership between GiveWell
-                      (founded in 2007 by Holden Karnofsky and Elie Hassenfeld) and Good Ventures
-                      (foundation started in 2011 by Cari Tuna and Dustin Moskovitz). They&apos;re
-                      mainly funded by Tuna and Moskovitz, but looking to work with more donors.
+                      Previously Open Philanthropy (renamed Coefficient Giving in November 2025), it
+                      grew out of a partnership between GiveWell (founded in 2007 by Holden Karnofsky
+                      and Elie Hassenfeld) and Good Ventures (foundation started in 2011 by Cari Tuna
+                      and Dustin Moskovitz). They&apos;re mainly funded by Tuna and Moskovitz, but
+                      looking to work with more donors.
                     </li>
                   </ul>
                 </li>
@@ -532,11 +541,16 @@ export default function AisFunderBulletinPage() {
                   Recent updates:
                   <ul>
                     <li>
-                      They&apos;re hiring for{' '}
+                      They&apos;ve stood up a new{' '}
+                      <A href="https://coefficientgiving.org/research/introducing-our-new-managing-director-of-public-policy/">
+                        US AI Policy team
+                      </A>{' '}
+                      under Managing Director of Public Policy Caleb Watney, and hire periodically for
+                      DC-based AI policy grantmaking and other roles (a recent round of{' '}
                       <A href="https://jobs.ashbyhq.com/coefficientgiving/5496d5b6-d7d2-4390-b577-af6b0c3bf24b">
-                        DC-based roles in US AI policy
-                      </A>
-                      ; applications are due August 2.
+                        US AI policy roles
+                      </A>{' '}
+                      closed in July 2026).
                     </li>
                   </ul>
                 </li>
@@ -625,7 +639,8 @@ export default function AisFunderBulletinPage() {
                       they&apos;re interested in donors giving at least $1m/year
                     </li>
                     <li>
-                      Apply for a job: no current open roles, but you can express interest{' '}
+                      Apply for a job: they periodically hire (including AI policy grantmaking
+                      roles); see current openings{' '}
                       <A href="https://www.longview.org/careers/">here</A>
                     </li>
                   </ul>
@@ -730,7 +745,11 @@ export default function AisFunderBulletinPage() {
                       those donating &gt; $100k
                     </li>
                     <li>
-                      Apply for a job: no current open roles, but you can express interest{' '}
+                      Apply for a job: they&apos;re hiring an{' '}
+                      <A href="https://jobs.ashbyhq.com/macroscopic/2fc5bd5f-d336-4af4-ad8b-b05ee0f43231">
+                        Operations Manager (Finance &amp; Compliance)
+                      </A>
+                      ; you can also express interest for other roles{' '}
                       <A href="https://jobs.ashbyhq.com/macroscopic/0d80e3a8-2ffd-4bef-8485-03f764732a6e">
                         here
                       </A>
@@ -780,8 +799,9 @@ export default function AisFunderBulletinPage() {
                   Recent updates:
                   <ul>
                     <li>
-                      The S-process grant rounds closed in April-July and recommendations will be
-                      announced in September-November.
+                      The 2026 S-process grant rounds closed in April-July (the Main Round added new
+                      Freedom and Fairness tracks, plus three cause-area Theme Rounds); recommendations
+                      are expected to be announced throughout fall 2026, by the end of November.
                     </li>
                   </ul>
                 </li>
@@ -814,9 +834,10 @@ export default function AisFunderBulletinPage() {
                     <li>
                       Apply for a job: They are currently hiring for a{' '}
                       <A href="https://survivalandflourishing.com/careers/full-stack-engineer">
-                        software engineer
-                      </A>{' '}
-                      role.
+                        full-stack software engineer
+                      </A>
+                      , as well as a product manager and a grants coordinator (see all roles{' '}
+                      <A href="https://survivalandflourishing.com/careers">here</A>).
                     </li>
                   </ul>
                 </li>
@@ -927,12 +948,16 @@ export default function AisFunderBulletinPage() {
                       Apply for funding:
                       <ul>
                         <li>
-                          They currently have a{' '}
-                          <A href="https://schmidtsciences.smapply.io/prog/scaling_ai_safety_for_a_multi_agent_world/">
-                            joint RFP on multi-agent safety
+                          They post periodic RFPs — recently a{' '}
+                          <A href="https://www.schmidtsciences.org/opportunity/2026-science-of-trustworthy-ai-rfp/">
+                            Science of Trustworthy AI RFP
                           </A>{' '}
-                          with Google DeepMind, Cooperative AI Foundation, and others with
-                          applications due August 8.
+                          (closed May 2026) and a{' '}
+                          <A href="https://schmidtsciences.smapply.io/prog/scaling_ai_safety_for_a_multi_agent_world/">
+                            joint call on multi-agent safety
+                          </A>{' '}
+                          with Google DeepMind, ARIA, the Cooperative AI Foundation, and Google.org
+                          (closed August 2026). No AI safety RFP is open right now.
                         </li>
                         <li>Otherwise, they don&apos;t accept unsolicited proposals.</li>
                       </ul>
@@ -972,7 +997,7 @@ export default function AisFunderBulletinPage() {
                   Recent updates:
                   <ul>
                     <li>
-                      Grants in the past month:
+                      Recent grants include:
                       <ul>
                         <li>$150,000 for AI safety workshops for middle schoolers in India</li>
                         <li>$77,000 for Sparse Concept Anchoring</li>
@@ -1094,8 +1119,8 @@ export default function AisFunderBulletinPage() {
                         </li>
                         <li>
                           <A href="https://bluedot.org/programs/rapid-grants">Rapid Grants</A>: up
-                          to $10k for concrete AI safety projects — application: 5 minutes, decision
-                          time: 3 days
+                          to $10k for concrete AI safety projects, events, and community-building —
+                          application: 5 minutes, decision time: ~5 working days
                         </li>
                       </ul>
                     </li>
@@ -1104,50 +1129,58 @@ export default function AisFunderBulletinPage() {
               </ul>
             </Funder>
 
-            <Funder title="Long-Term Future Fund (LTFF)">
+            <Funder title="Transformative AI Fund (formerly LTFF)">
               <ul>
                 <li>
-                  <A href="https://funds.effectivealtruism.org/funds/far-future">Website</A>
+                  <A href="https://funds.effectivealtruism.org/funds/transformative-ai">Website</A>
                 </li>
                 <li>
                   Background:
                   <ul>
-                    <li>Started in 2017 as a project of Centre for Effective Altruism.</li>
+                    <li>
+                      The Long-Term Future Fund (LTFF) started in 2017 as a project of the Centre for
+                      Effective Altruism. In August 2026, EA Funds{' '}
+                      <A href="https://forum.effectivealtruism.org/posts/dtZ9wbKWjtvGWDRJx/closing-the-ltff-spending-down-funds-and-a-new-ai-fund-at-ea">
+                        announced it was closing the LTFF
+                      </A>{' '}
+                      and{' '}
+                      <A href="https://forum.effectivealtruism.org/posts/dYuNi5Rh68o9YKstg/ea-funds-is-launching-the-transformative-ai-fund">
+                        launching the Transformative AI Fund
+                      </A>{' '}
+                      (TAIF) as its successor, with a new full-time team led by Lowe Lundin.
+                    </li>
                   </ul>
                 </li>
                 <li>
                   Thesis:
                   <ul>
                     <li>
-                      Focused on giving small grants of $5k-$200k for individuals, independent
-                      researchers, and new projects. They&apos;re currently in a transitional
-                      period, so funding may be delayed.
+                      TAIF makes early-stage grants to individuals, new organizations, and new
+                      projects reducing risks from transformative AI, spanning technical AI safety, AI
+                      governance, and field-building. It is always open to applications.
                     </li>
                   </ul>
                 </li>
                 <li>
                   By the numbers:
                   <ul>
-                    <li>donating: historically around $6m/year</li>
-                    <li>number of grants: 100-200/year</li>
-                    <li>grant size: between $5k-$200k</li>
-                    <li>staff: all part-time, ~1 FTE</li>
+                    <li>
+                      LTFF historically donated around $6m/year across 100-200 grants; TAIF launched
+                      with a ~$1M seed and hopes to raise more
+                    </li>
+                    <li>grant size: typically $10k-$150k, rarely above $300k</li>
+                    <li>staff: full-time Head of Fund (Lowe Lundin) plus part-time grantmakers</li>
                   </ul>
                 </li>
                 <li>
                   Recent updates:
                   <ul>
                     <li>
-                      They haven&apos;t posted grant updates since 2024 Q1. As of April 2026, they{' '}
-                      <A href="https://forum.effectivealtruism.org/posts/MaAzwX3erHW3rD53B/a-brief-update-on-ea-funds-and-a-recruitment-announcement">
-                        announced
-                      </A>{' '}
-                      that they were in the process of hiring new leadership and were in a
-                      transitional period.
-                    </li>
-                    <li>
-                      They are donating $2M to this{' '}
-                      <A href="https://www.lightconecommons.com/">Lightcone Commons</A> round.
+                      The LTFF is spending down its remaining ~$3.7M balance — roughly three-quarters
+                      to existing longtermist applications, largely via the first{' '}
+                      <A href="https://www.lightconecommons.com/">Lightcone Commons</A> round (~$2M to
+                      that round), and ~$0.9M to seed TAIF. Its last payout report covers May 2023 to
+                      March 2024.
                     </li>
                   </ul>
                 </li>
@@ -1155,10 +1188,8 @@ export default function AisFunderBulletinPage() {
                   Get involved:
                   <ul>
                     <li>
-                      Apply for funding: use{' '}
-                      <A href="https://av20jp3z.paperform.co/?fund=Long-Term%20Future%20Fund">
-                        this form
-                      </A>
+                      Apply for funding: apply to the Transformative AI Fund{' '}
+                      <A href="https://funds.effectivealtruism.org/funds/transformative-ai">here</A>
                     </li>
                     <li>
                       Donate: donate to EA Funds{' '}
@@ -1176,14 +1207,12 @@ export default function AisFunderBulletinPage() {
         <CollapsibleSection title="Not included">
           <ul className="space-y-3 text-sm text-gray-600 [&_a]:text-orange-600">
             <li>
-              <A href="https://astralisfoundation.org/">Astralis Foundation</A>: They seem fairly
-              new with not a ton of public info. They&apos;re not taking unsolicited funding
-              requests. Based on{' '}
-              <A href="https://web.archive.org/web/20260121035945/https://effectivealtruism.nz/job-board/ai-governance-fund-lead-astralis-foundation">
-                this job posting
-              </A>{' '}
-              from earlier in the year, they have a fund focused on international AI governance
-              aiming to deploy $15m this year.
+              <A href="https://astralisfoundation.org/">Astralis Foundation</A>: A European-based
+              multi-donor AI-safety grantmaker that has grown considerably — reportedly raising over
+              $20m from around 15 donors and supporting ~14 organizations. Its Shared Horizons Fund
+              focuses on international AI governance (including European and Chinese policy
+              ecosystems). They still don&apos;t appear to take unsolicited funding requests, so
+              they remain in this section for now.
             </li>
             <li>
               <A href="https://www.navigation.org/">Navigation Fund</A>: Jed McCaleb&apos;s
@@ -1195,21 +1224,29 @@ export default function AisFunderBulletinPage() {
               it&apos;s now gone from their website.
             </li>
             <li>
-              <A href="https://www.airiskfund.com/">AI Risk Mitigation Fund</A>: They announced a
-              spinoff from LTFF in 2023, but haven&apos;t made any updates or grant announcements on
-              their website. They&apos;re one of the funders of Lightcone Commons.
+              <A href="https://www.airiskfund.com/">AI Risk Mitigation Fund (ARM Fund)</A>: A spinoff
+              from LTFF announced in 2023. It&apos;s one of the funders of Lightcone Commons
+              (contributing ~$2M to the first round), and as part of the LTFF wind-down, several
+              departing LTFF managers plan to continue part-time grantmaking through the ARM Fund, so
+              it may become more active.
             </li>
             <li>
               <A href="https://futureoflife.org/">FLI</A>: They were previously more active in
-              grantmaking and still have a PhD fellowship program, but seem to be less focused on
-              grantmaking these days.
+              grantmaking and still run PhD fellowship programs, but seem to be less focused on
+              grantmaking these days — and they are{' '}
+              <A href="https://futureoflife.org/grant-program/phd-fellowships/">
+                pausing new fellowship applications
+              </A>{' '}
+              in fall 2026 to reassess the program.
             </li>
             <li>
               <A href="https://www.frontiermodelforum.org/ai-safety-fund/">
                 Frontier Model Forum AI Safety Fund
               </A>
-              : It was funded with $10m in 2023. Most of this was distributed in 2024 and 2025 and
-              they now appear to be winding down and spending their remaining funds.
+              : It was funded with $10m+ in 2023 and has run two grant rounds (the second announced
+              December 2025). After the Meridian Institute wound down in 2025, FMF began managing the
+              fund directly and is now directing remaining funds to narrowly-scoped, urgent-bottleneck
+              projects.
             </li>
             <li>
               <A href="https://foresight.org/grants/grants-ai-for-science-safety/">
@@ -1222,12 +1259,13 @@ export default function AisFunderBulletinPage() {
               they&apos;re primarily backing <A href="https://www.simplexaisafety.com/">Simplex</A>.
             </li>
             <li>
-              <A href="http://grantmaking.ai">grantmaking.ai</A>: New initiative housed under
-              Manifund, with an initial $1m, see{' '}
+              <A href="http://grantmaking.ai">grantmaking.ai</A>: Initiative housed under Manifund; its
+              inaugural $1m AI x-risk round (see{' '}
               <A href="https://www.lesswrong.com/posts/hDQZZzYkcipgaZfxy/usd1m-ai-x-risk-grant-round-is-live-on-grantmaking-ai-apply">
                 launch post
               </A>
-              .
+              ) has now closed to applications, and the platform continues as a public
+              funding-opportunities database.
             </li>
           </ul>
         </CollapsibleSection>


### PR DESCRIPTION
Re-verified every figure, link, and claim on the AI Safety Funder Bulletin; the biggest change is that the LTFF is closing and being replaced by EA Funds' new Transformative AI Fund, plus Schmidt Sciences' RFPs have all closed and several funders now have open roles.

## Changes (with sources)

**LTFF → Transformative AI Fund (major)** — EA Funds announced in Aug 2026 it is closing the LTFF and launching the Transformative AI Fund (TAIF), led full-time by Lowe Lundin. Updated the At-a-glance row (name → "Transformative AI Fund", href → the TAIF fund page, expected 2026 → $4M with a new footnote), and rewrote the profile (background/thesis/by-the-numbers/recent-updates/get-involved) to reflect the closure and successor. LTFF is spending down its remaining ~$3.7M — ~¾ to existing applications largely via the first Lightcone Commons round (~$2M to that round), ~$0.9M seeding TAIF.
  - https://forum.effectivealtruism.org/posts/dtZ9wbKWjtvGWDRJx/closing-the-ltff-spending-down-funds-and-a-new-ai-fund-at-ea
  - https://forum.effectivealtruism.org/posts/dYuNi5Rh68o9YKstg/ea-funds-is-launching-the-transformative-ai-fund
  - https://funds.effectivealtruism.org/funds/transformative-ai

**Schmidt Sciences — Open RFPs YES → NO.** Both AI-safety RFPs have closed (Science of Trustworthy AI, deadline May 17, 2026; Scaling AI Safety for a Multi-Agent World, deadline Aug 9, 2026). Flipped the At-a-glance flag and reworded "Get involved" to the durable state, correcting the multi-agent partner list to include ARIA and Google.org.
  - https://www.schmidtsciences.org/opportunity/2026-science-of-trustworthy-ai-rfp/
  - https://schmidtsciences.smapply.io/prog/scaling_ai_safety_for_a_multi_agent_world/

**Coefficient Giving** — Noted the rename from Open Philanthropy (Nov 18, 2025) in the profile; the "applications due August 2" US-AI-policy hiring note was stale (that round actually closed July 23, 2026), so reworded to describe the new US AI Policy team under Caleb Watney and durable periodic hiring.
  - ``https://coefficientgiving.org/research/press-release-open-philanthropy-becomes-coefficient-giving-expanding-work-with-multiple-donors``/
  - https://coefficientgiving.org/research/introducing-our-new-managing-director-of-public-policy/

**Longview Philanthropy** — Jobs line "no current open roles" was out of date; reworded to point to current openings (incl. AI policy grantmaking roles).
  - https://www.longview.org/careers/

**Macroscopic** — Jobs line "no current open roles" was out of date; there's an open Operations Manager (Finance & Compliance) role.
  - https://jobs.ashbyhq.com/macroscopic/2fc5bd5f-d336-4af4-ad8b-b05ee0f43231

**SFF** — Updated the 2026 timeline (rounds added Freedom/Fairness tracks + three Theme Rounds; recommendations expected by end of Nov 2026) and expanded the jobs line from one role to three (full-stack engineer, product manager, grants coordinator).
  - https://survivalandflourishing.fund/2026/application
  - https://survivalandflourishing.com/careers

**BlueDot Impact** — Rapid Grants decision time "3 days" → "~5 working days" and broadened scope to include events/community-building.
  - https://blog.bluedot.org/p/weve-given-out-50000-in-rapid-grants

**AISTOF** — Reworded the stale "Grants in the past month" to "Recent grants include" (no fresher public grant list found).

**Not included section** — Astralis Foundation rewritten (now a >$20M multi-donor grantmaker with a Shared Horizons Fund for international AI governance); ARM Fund updated (poised to become more active as LTFF managers move part-time grantmaking there); FLI updated (pausing new fellowship applications in fall 2026); Frontier Model Forum AI Safety Fund reworded (ran a second grant round Dec 2025, not clearly winding down); grantmaking.ai updated (inaugural $1m round has closed to applications).
  - https://astralisfoundation.org/ · https://www.airiskfund.com/ · https://futureoflife.org/grant-program/phd-fellowships/ · https://www.frontiermodelforum.org/ai-safety-fund/ · https://app.grantmaking.ai/

Bumped `LAST_UPDATED` to August 18, 2026. Footnote count unchanged (20); no renumbering needed (only note 20's text/node were rewritten for the TAIF transition).

## Per-funder research log

- **Coefficient Giving** — Rename to Coefficient Giving (Nov 18, 2025) and "13 funds" framing confirmed; $1B-to-catastrophic-risks-in-2026 and both open RFPs (capacity-building, career transition) confirmed still open. The $400M/226/184/46 At-a-glance figures depend on the live coefficientgiving.org/funds database, which was **not reachable** this run (see caveat) — left unchanged rather than guessing. Updated the stale hiring note.
- **Longview Philanthropy** — $60M (2025) and $266M cumulative confirmed; $350M-expected-2026 derivation still stands. Both 2026 RFPs (Extreme Power Concentration, Digital Minds) closed → Open RFPs stays NO. Jobs line updated (they're hiring).
- **OpenAI Foundation** — $130M initial AI-resilience grants / $1B-across-cause-areas / ~$250M AIS estimate and 2 publicly-listed AI-resilience staff all confirmed; $0/0 for 2025 stays (their Dec 2025 $40.5M was community grants, not AI safety). No edit needed.
- **Macroscopic** — $30M (2025) and up-to-$100M (2026) confirmed; open Operations Manager role added. Left FTE at 8 (the "team of 14" figure is total staff, not AIS-amortized, and I couldn't source an AIS-only split).
- **SFF** — 2025 total $34.33M (rounds to $35M) confirmed; 2026 plan $20–40M confirmed; timeline and jobs updated. Left grant count "89" (couldn't independently re-confirm the exact count; recommendations page unreachable).
- **Lightcone Commons** — $20M first round, Aug 23 application deadline (still upcoming), and Oct 23 recommendations all confirmed current; funders (Tallinn/Moskovitz/LTFF/ARM) confirmed. No edit needed this run.
- **Schmidt Sciences** — $10M/27 grants (2025) confirmed; both RFPs closed → flag flipped and prose reworded.
- **AISTOF** — >$30M raised / >150 grants / ~1 FTE confirmed; no grants newer than those already listed, so only softened the "past month" wording.
- **Manifund** — manifund.org (incl. /about) was **not reachable** this run, so the $6M/234 (2025) and $3.7M/~100 (2026 YTD) figures could not be re-verified against the live about page; left unchanged per the "don't guess" rule.
- **BlueDot Impact** — Rapid Grants ~5-working-day decision confirmed; both programs open. The $3.8M/~500-grants and 17-day figures couldn't be verified (bluedot.org unreachable), so left unchanged.
- **Transformative AI Fund (formerly LTFF)** — Closure + TAIF launch confirmed across three independent sources; row and profile rewritten.

## Verification caveat

This environment's egress policy blocked direct fetches (HTTP 403) to the funder/EA domains (coefficientgiving.org, longview.org, manifund.org, survivalandflourishing.fund, forum.effectivealtruism.org, web.archive.org, etc.), so verification relied on web search over live/indexed page content rather than opening each page directly. Figures that live only on JS-rendered pages I couldn't reach — chiefly the Coefficient funds-database counts and the Manifund about-page totals — were left unchanged rather than estimated. A reviewer on an unrestricted network may want to open those two pages to confirm their current numbers.

## Build

`bun install && bun run build` compiles and passes TypeScript. The build's static-export step fails on unrelated Supabase-backed pages (`/causes`, `/about/donate`) because Supabase env vars aren't set in this sandbox — this failure reproduces identically on a clean checkout without these changes; the bulletin page is a static server component with no data fetching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KA5BrQbjyfciojPa4bFLuT)_