### PR TITLE
Add Stripe issues warning to withdrawal flow

### DIFF
--- a/app/withdraw/withdrawal-steps.tsx
+++ b/app/withdraw/withdrawal-steps.tsx
@@ -110,7 +110,7 @@ export function WithdrawalSteps(props: {
       <StepsDisplay steps={steps} currentStepId={currentStepIdx + 1} complete={complete} />
       <Row className="w-full justify-center p-10">
         <div className="w-full max-w-2xl">
-          <p className="mb-6 rounded-md bg-rose-100 p-4 text-sm font-bold text-rose-700">
+          <p className="mb-6 rounded-md bg-amber-100 p-4 text-sm font-bold text-amber-800">
             Note: we&apos;re experiencing issues with our Stripe account right now. Fill out{' '}
             <a
               href="https://airtable.com/shrI3XFPivduhbnGa"

--- a/app/withdraw/withdrawal-steps.tsx
+++ b/app/withdraw/withdrawal-steps.tsx
@@ -110,6 +110,18 @@ export function WithdrawalSteps(props: {
       <StepsDisplay steps={steps} currentStepId={currentStepIdx + 1} complete={complete} />
       <Row className="w-full justify-center p-10">
         <div className="w-full max-w-2xl">
+          <p className="mb-6 rounded-md bg-rose-100 p-4 text-sm font-bold text-rose-700">
+            Note: we&apos;re experiencing issues with our Stripe account right now. Fill out{' '}
+            <a
+              href="https://airtable.com/shrI3XFPivduhbnGa"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              our form
+            </a>{' '}
+            to withdraw amounts greater than $100.
+          </p>
           {steps[currentStepIdx].display}
           <Row className="mt-10 justify-between">
             <button

--- a/app/withdraw/withdrawal-steps.tsx
+++ b/app/withdraw/withdrawal-steps.tsx
@@ -110,7 +110,7 @@ export function WithdrawalSteps(props: {
       <StepsDisplay steps={steps} currentStepId={currentStepIdx + 1} complete={complete} />
       <Row className="w-full justify-center p-10">
         <div className="w-full max-w-2xl">
-          <p className="mb-6 rounded-md bg-amber-100 p-4 text-sm font-bold text-amber-800">
+          <p className="mb-6 rounded-md bg-orange-100 p-4 text-sm font-bold text-orange-700">
             Note: we&apos;re experiencing issues with our Stripe account right now. Fill out{' '}
             <a
               href="https://airtable.com/shrI3XFPivduhbnGa"


### PR DESCRIPTION
Bold warning on the withdraw flow pointing users to the manual withdrawal form for amounts over $100 while our Stripe account has issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)