### PR TITLE
Add PostHog analytics

### DIFF
--- a/app/projects/[slug]/agreement/grant-agreement.tsx
+++ b/app/projects/[slug]/agreement/grant-agreement.tsx
@@ -12,7 +12,7 @@ export function GrantAgreement(props: { project: ProjectAndProfile; agreement?: 
   const excludeLobbyingClause = signed ? agreement.lobbying_clause_excluded : project.lobbying
   const version = signed && agreement?.version ? agreement.version : CURRENT_AGREEMENT_VERSION
   return (
-    <table className="text-gray-900">
+    <table className="ph-no-capture text-gray-900">
       <tbody>
         <tr className="font-bold">
           <td className="pr-10 ">1</td>

--- a/app/projects/[slug]/agreement/org-grant-agreement.tsx
+++ b/app/projects/[slug]/agreement/org-grant-agreement.tsx
@@ -89,7 +89,7 @@ export function OrgGrantAgreement(props: {
   }
 
   return (
-    <table className="text-gray-900">
+    <table className="ph-no-capture text-gray-900">
       <tbody>
         <tr className="font-bold">
           <td className="pr-10">1</td>

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "next": "16.2.4",
         "node-html-markdown": "^1.3.0",
         "openai": "^5.0.1",
+        "posthog-js": "^1.418.13",
         "react": "19.2.5",
         "react-beautiful-dnd": "^13.1.1",
         "react-compare-slider": "^3.0.1",
@@ -335,6 +336,12 @@
 
     "@popperjs/core": ["@popperjs/core@2.11.8", "", {}, "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="],
 
+    "@posthog/browser-common": ["@posthog/browser-common@0.5.0", "", { "dependencies": { "@posthog/core": "^1.47.0", "@posthog/types": "^1.402.2" } }, "sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q=="],
+
+    "@posthog/core": ["@posthog/core@1.48.9", "", { "dependencies": { "@posthog/types": "^1.405.1" } }, "sha512-jKJyG12L0TcLaa0av6lmSl8pLANUmvp2RVebM0/FYa/gID47BAVzuj3fT6QPJ7RZe0U4QZGQIrkB1amVYfBcig=="],
+
+    "@posthog/types": ["@posthog/types@1.405.2", "", {}, "sha512-NVsw5pER9YEDFOfvmbpyRtIgv+0411QXHg1IjCFh+EcxtmLUP2FdJyiWYVpNM6WhTTlrPEW+fPZpGz1OBXijvQ=="],
+
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.2", "", {}, "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="],
@@ -558,6 +565,8 @@
     "@types/responselike": ["@types/responselike@1.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA=="],
 
     "@types/semver": ["@types/semver@7.7.0", "", {}, "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/urijs": ["@types/urijs@1.19.25", "", {}, "sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg=="],
 
@@ -823,6 +832,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.50.0", "", {}, "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw=="],
+
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -944,6 +955,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.14", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1084,6 +1097,8 @@
     "fdir": ["fdir@6.4.5", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw=="],
 
     "fetch-retry": ["fetch-retry@5.0.5", "", {}, "sha512-q9SvpKH5Ka6h7X2C6r1sP31pQoeDb3o6/R9cg21ahfPAqbIOkW9tus1dXfwYb6G6dOI4F7nVS4Q+LSssBGIz0A=="],
+
+    "fflate": ["fflate@0.4.9", "", {}, "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw=="],
 
     "fictional": ["fictional@2.1.1", "", { "dependencies": { "decimal.js": "^10.4.3", "fast-json-stable-stringify": "^2.1.0", "fnv-plus": "^1.3.1", "siphash": "^1.1.0" } }, "sha512-lHrMISII22AXlro16kjq0tTEr+LWWQwPVT3h3H8Xxd1pDr3sTI+ZxNOpp/SQm1wrY1jr5A7taOxJAOXvnLdjVQ=="],
 
@@ -1653,9 +1668,13 @@
 
     "postgresql-client": ["postgresql-client@2.5.5", "", { "dependencies": { "debug": "^4.3.4", "doublylinked": "^2.5.2", "lightning-pool": "^4.2.1", "postgres-bytea": "^3.0.0", "power-tasks": "^1.6.4", "putil-merge": "^3.10.3", "putil-promisify": "^1.10.0", "putil-varhelpers": "^1.6.5" } }, "sha512-2Mu3i+6NQ9cnkoZNd0XeSZo9WoUpuWf4ZSiCCoDWSj82T93py2/SKXZ1aUaP8mVaU0oKpyyGe0IwLYZ1VHShnA=="],
 
+    "posthog-js": ["posthog-js@1.418.13", "", { "dependencies": { "@posthog/browser-common": "^0.5.0", "@posthog/core": "^1.48.9", "@posthog/types": "^1.405.2", "core-js": "^3.49.0", "dompurify": "^3.4.13", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0", "web-vitals-soft-navs": "npm:web-vitals@6.0.0" } }, "sha512-EwBi0M3sn8Hmes6Iu1Oav65+COt6fUL+eSC50lz1eSfABWsNxQndWT1LjxYd6nxvMUnV3NJkcZTeRor4lOENXw=="],
+
     "posthog-node": ["posthog-node@3.1.2", "", { "dependencies": { "axios": "^0.27.0", "rusha": "^0.8.14" } }, "sha512-atPGYjiK+QvtseKKsrUxMrzN84sIVs9jTa7nx5hl999gJly1S3J5r0DApwZ69NKfJkVIeLTCJyT0kyS+7WqDSw=="],
 
     "power-tasks": ["power-tasks@1.11.0", "", { "dependencies": { "doublylinked": "^2.5.4", "strict-typed-events": "^2.8.0", "tslib": "^2.6.3" } }, "sha512-UAVmqOw4miD+BW4gBrL1KJb24akTUfy1XglIFB7domD7Wyj0eQAyK9F9PnYYiw1pVLoyy3L+HfCYWwN2sMwCzg=="],
+
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -1726,6 +1745,8 @@
     "putil-varhelpers": ["putil-varhelpers@1.6.5", "", {}, "sha512-kyu+lE5xkc65ScgaIi6rNONLXeS7jGBxl1I0rzHVsFGAAQ45D/VkuEev+t09PFB943F+CqdWFLczH6ePk5TPAA=="],
 
     "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -2068,6 +2089,10 @@
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
+
+    "web-vitals-soft-navs": ["web-vitals@6.0.0", "", {}, "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 

--- a/components/withdrawal-details.tsx
+++ b/components/withdrawal-details.tsx
@@ -79,7 +79,7 @@ export function WithdrawalDetails(props: {
   }
   const isBank = withdrawalMethod.object === 'bank_account'
   return (
-    <Col className="gap-10">
+    <Col className="ph-no-capture gap-10">
       <Link
         href="https://airtable.com/shrI3XFPivduhbnGa"
         className="rounded-md bg-orange-500 p-3 text-sm font-semibold text-white shadow hover:bg-orange-600"

--- a/db/env.ts
+++ b/db/env.ts
@@ -24,6 +24,8 @@ export const NEXT_PUBLIC_STRIPE_KEY =
 export const STRIPE_SECRET_KEY =
   SUPABASE_ENV === 'PROD' ? process.env.STRIPE_LIVE_SECRET_KEY : process.env.STRIPE_TEST_SECRET_KEY
 
+export const NEXT_PUBLIC_POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY
+
 export function isProd() {
   return SUPABASE_ENV === 'PROD'
 }

--- a/db/supabase-provider.tsx
+++ b/db/supabase-provider.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import posthog from 'posthog-js'
 import { createContext, useContext, useEffect, useState } from 'react'
 import { createClient } from './supabase-browser'
 
@@ -25,12 +26,35 @@ export default function SupabaseProvider(props: { children: React.ReactNode; cla
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((event, session) => {
       setSession(session)
+      if (event === 'SIGNED_OUT' && posthog.__loaded) {
+        posthog.reset()
+      }
     })
 
     return () => subscription.unsubscribe()
   }, [supabase])
+
+  // With memory persistence PostHog forgets identity on every hard page load, so re-identify
+  // whenever a session is present. posthog.__loaded is false in dev, where init never runs.
+  const userId = session?.user?.id
+  useEffect(() => {
+    if (!userId || !posthog.__loaded) return
+    void supabase
+      .from('profiles')
+      .select('username, full_name')
+      .eq('id', userId)
+      .single()
+      .then(({ data }) => {
+        posthog.identify(userId, {
+          email: session?.user?.email,
+          username: data?.username,
+          name: data?.full_name,
+        })
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId, supabase])
 
   return (
     <Context.Provider value={{ supabase, session }}>

--- a/db/supabase-provider.tsx
+++ b/db/supabase-provider.tsx
@@ -36,8 +36,6 @@ export default function SupabaseProvider(props: { children: React.ReactNode; cla
     return () => subscription.unsubscribe()
   }, [supabase])
 
-  // With memory persistence PostHog forgets identity on every hard page load, so re-identify
-  // whenever a session is present. posthog.__loaded is false in dev, where init never runs.
   const userId = session?.user?.id
   useEffect(() => {
     if (!userId || !posthog.__loaded) return

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,17 +1,13 @@
 import posthog from 'posthog-js'
 import { NEXT_PUBLIC_POSTHOG_KEY } from './db/env'
 
-// Gate on NODE_ENV, not isProd(): `bun run dev` uses prod Supabase but must not send analytics.
-// The key is only set in Vercel's Production environment, so preview deploys are excluded too.
+// NODE_ENV gate rather than isProd(): `bun run dev` uses prod Supabase but must not send analytics
 if (process.env.NODE_ENV === 'production' && NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(NEXT_PUBLIC_POSTHOG_KEY, {
-    // First-party reverse proxy (see rewrites in next.config.js) so adblockers don't block capture
-    api_host: '/flux',
+    api_host: '/flux', // reverse-proxied to PostHog via rewrites in next.config.js
     ui_host: 'https://us.posthog.com',
     defaults: '2026-08-29',
-    // Nothing is stored on the user's device, so no cookie consent banner is needed.
-    // Anonymous visitors get a new id per hard page load; logged-in users are stitched via identify().
-    persistence: 'memory',
+    persistence: 'memory', // nothing stored on device, so no cookie banner needed
     capture_pageleave: true,
     session_recording: {
       maskAllInputs: true,

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,21 @@
+import posthog from 'posthog-js'
+import { NEXT_PUBLIC_POSTHOG_KEY } from './db/env'
+
+// Gate on NODE_ENV, not isProd(): `bun run dev` uses prod Supabase but must not send analytics.
+// The key is only set in Vercel's Production environment, so preview deploys are excluded too.
+if (process.env.NODE_ENV === 'production' && NEXT_PUBLIC_POSTHOG_KEY) {
+  posthog.init(NEXT_PUBLIC_POSTHOG_KEY, {
+    // First-party reverse proxy (see rewrites in next.config.js) so adblockers don't block capture
+    api_host: '/flux',
+    ui_host: 'https://us.posthog.com',
+    defaults: '2026-08-29',
+    // Nothing is stored on the user's device, so no cookie consent banner is needed.
+    // Anonymous visitors get a new id per hard page load; logged-in users are stitched via identify().
+    persistence: 'memory',
+    capture_pageleave: true,
+    session_recording: {
+      maskAllInputs: true,
+      maskInputOptions: { password: true },
+    },
+  })
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  // PostHog API paths end in '/'; Next's automatic 308 trailing-slash redirect would break them.
+  // The redirect is re-implemented for app routes in proxy.ts.
+  skipTrailingSlashRedirect: true,
   images: {
     remotePatterns: [
       {
@@ -28,6 +31,23 @@ const nextConfig = {
         pathname: '/a/h06lDL9',
       },
     ],
+  },
+  // Reverse proxy for PostHog under an innocuous path so adblockers don't block it
+  async rewrites() {
+    return [
+      {
+        source: '/flux/static/:path*',
+        destination: 'https://us-assets.i.posthog.com/static/:path*',
+      },
+      {
+        source: '/flux/array/:path*',
+        destination: 'https://us-assets.i.posthog.com/array/:path*',
+      },
+      {
+        source: '/flux/:path*',
+        destination: 'https://us.i.posthog.com/:path*',
+      },
+    ]
   },
   async redirects() {
     return [

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
-  // PostHog API paths end in '/'; Next's automatic 308 trailing-slash redirect would break them.
-  // The redirect is re-implemented for app routes in proxy.ts.
+  // PostHog API paths end in '/'; the trailing-slash redirect is re-implemented in proxy.ts
   skipTrailingSlashRedirect: true,
   images: {
     remotePatterns: [
@@ -32,7 +31,7 @@ const nextConfig = {
       },
     ],
   },
-  // Reverse proxy for PostHog under an innocuous path so adblockers don't block it
+  // Reverse proxy for PostHog so adblockers don't block it
   async rewrites() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "next": "16.2.4",
     "node-html-markdown": "^1.3.0",
     "openai": "^5.0.1",
+    "posthog-js": "^1.418.13",
     "react": "19.2.5",
     "react-beautiful-dnd": "^13.1.1",
     "react-compare-slider": "^3.0.1",

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,11 +3,10 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from './db/env'
 
 export async function proxy(request: NextRequest) {
-  // Re-implement Next's trailing-slash redirect, disabled globally via skipTrailingSlashRedirect
-  // in next.config.js so the /flux/* PostHog proxy paths keep their trailing slashes.
+  // Trailing-slash redirect, disabled globally in next.config.js so /flux/* keeps its slashes.
+  // Plain URL, not nextUrl.clone(): NextURL re-normalizes the pathname back to a trailing slash.
   const { pathname, search } = request.nextUrl
   if (pathname !== '/' && pathname.endsWith('/')) {
-    // Plain URL, not nextUrl.clone(): NextURL re-normalizes the pathname back to a trailing slash
     return NextResponse.redirect(new URL(pathname.slice(0, -1) + search, request.url), 308)
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,6 +3,14 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { SUPABASE_ANON_KEY, SUPABASE_URL } from './db/env'
 
 export async function proxy(request: NextRequest) {
+  // Re-implement Next's trailing-slash redirect, disabled globally via skipTrailingSlashRedirect
+  // in next.config.js so the /flux/* PostHog proxy paths keep their trailing slashes.
+  const { pathname, search } = request.nextUrl
+  if (pathname !== '/' && pathname.endsWith('/')) {
+    // Plain URL, not nextUrl.clone(): NextURL re-normalizes the pathname back to a trailing slash
+    return NextResponse.redirect(new URL(pathname.slice(0, -1) + search, request.url), 308)
+  }
+
   let supabaseResponse = NextResponse.next({ request })
 
   const supabase = createServerClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
@@ -28,6 +36,8 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  // Skip static assets so the proxy only runs on requests that use Supabase
-  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
+  // Skip static assets and the PostHog proxy (/flux) so the proxy only runs on requests that use Supabase
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|flux/|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
 }


### PR DESCRIPTION
Integrates posthog-js with memory persistence (no cookie banner needed), a first-party reverse proxy at /flux so adblockers don't block it, session replay with all inputs masked, and identify/reset wired into SupabaseProvider. Prod-only via NODE_ENV gate; needs NEXT_PUBLIC_POSTHOG_KEY set in Vercel's Production env before it activates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)