### PR TITLE
[reference only] Vibecode a wrapper around Mercury to input intl bank details

### DIFF
--- a/app/withdraw-mercury/actions.ts
+++ b/app/withdraw-mercury/actions.ts
@@ -124,7 +124,7 @@ export async function withdrawViaMercury(
     }
   }
 
-  const accountId = process.env.MERCURY_ACCOUNT_ID
+  const accountId = process.env.MERCURY_GRANTS_ACCOUNT_ID
   if (!accountId) {
     return { success: false, error: 'Mercury account not configured' }
   }
@@ -155,6 +155,7 @@ export async function withdrawViaMercury(
         recipientId: profile.mercury_recipient_id,
         amount,
         paymentMethod: 'ach',
+        idempotencyKey: txnId,
         note: `Manifund withdrawal for ${profile.full_name} (${txnId})`,
       }),
     }

--- a/app/withdraw-mercury/actions.ts
+++ b/app/withdraw-mercury/actions.ts
@@ -3,6 +3,9 @@
 import { getUser } from '@/db/profile'
 import { createServerSupabaseClient } from '@/db/supabase-server'
 import { revalidatePath } from 'next/cache'
+import { getTxnAndProjectsByUser } from '@/db/txn'
+import { getBidsByUser } from '@/db/bid'
+import { calculateCashBalance } from '@/utils/math'
 
 export type ElectronicAccountType =
   | 'businessChecking'
@@ -125,7 +128,7 @@ export async function getMercuryRecipient(userId: string) {
 
   const { data: profile, error } = await supabase
     .from('profiles')
-    .select('mercury_recipient_id')
+    .select('mercury_recipient_id, accreditation_status')
     .eq('id', userId)
     .single()
 
@@ -144,7 +147,7 @@ export async function getMercuryRecipient(userId: string) {
 
   try {
     const response = await fetch(
-      `https://api.mercury.com/api/v1/recipient/${profile.mercury_recipient_id}`,
+      `https://api.mercury.com/api/v1/recipients/${profile.mercury_recipient_id}`,
       {
         headers: {
           Authorization: `Bearer ${apiKey}`,
@@ -157,14 +160,149 @@ export async function getMercuryRecipient(userId: string) {
     }
 
     const data = await response.json()
+
+    // Also calculate the user's withdrawable balance
+    const txns = await getTxnAndProjectsByUser(supabase, userId)
+    const bids = await getBidsByUser(supabase, userId)
+    const withdrawBalance = calculateCashBalance(
+      txns,
+      bids,
+      userId,
+      profile.accreditation_status
+    )
+
     return {
       id: data.id,
       name: data.name,
       accountLastFour: data.electronicRoutingInfo?.accountNumber?.slice(-4),
       electronicAccountType: data.electronicRoutingInfo?.electronicAccountType,
+      withdrawBalance,
     }
   } catch (error) {
     console.error('Error fetching Mercury recipient:', error)
     return null
+  }
+}
+
+export type WithdrawResult =
+  | { success: true; transactionId: string }
+  | { success: false; error: string }
+
+export async function withdrawViaMercury(
+  amount: number
+): Promise<WithdrawResult> {
+  const supabase = await createServerSupabaseClient()
+  const user = await getUser(supabase)
+
+  if (!user || !user.id) {
+    return { success: false, error: 'User not found' }
+  }
+
+  // Get user's Mercury recipient ID and profile info
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('mercury_recipient_id, full_name, accreditation_status')
+    .eq('id', user.id)
+    .single()
+
+  if (profileError || !profile || !profile.mercury_recipient_id) {
+    return {
+      success: false,
+      error:
+        'No Mercury recipient found. Please connect your bank account first.',
+    }
+  }
+
+  // Get user's balance using the same logic as stripe-connect-withdraw
+  const txns = await getTxnAndProjectsByUser(supabase, user.id)
+  const bids = await getBidsByUser(supabase, user.id)
+  const withdrawBalance = calculateCashBalance(
+    txns,
+    bids,
+    user.id,
+    profile.accreditation_status
+  )
+
+  if (amount > withdrawBalance) {
+    return { success: false, error: `Insufficient balance. Available balance: $${withdrawBalance.toFixed(2)}` }
+  }
+
+  const apiKey = process.env.MERCURY_API_KEY
+  const accountId = process.env.MERCURY_ACCOUNT_ID
+
+  if (!apiKey || !accountId) {
+    return { success: false, error: 'Mercury configuration missing' }
+  }
+
+  // Create transaction ID
+  const txnId = crypto.randomUUID()
+
+  try {
+    // Create transaction record first
+    const { error: insertError } = await supabase.from('txns').insert({
+      id: txnId,
+      from_id: user.id,
+      to_id: process.env.NEXT_PUBLIC_PROD_BANK_ID ?? 'bank',
+      amount: amount,
+      token: 'USD',
+      type: 'withdraw',
+      project: null,
+    })
+
+    if (insertError) {
+      console.error('Failed to create transaction:', insertError)
+      return { success: false, error: 'Failed to create transaction record' }
+    }
+
+    // Send money via Mercury API
+    const response = await fetch(
+      'https://api.mercury.com/api/v1/account/request-send-money',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          accountId: accountId,
+          recipientId: profile.mercury_recipient_id,
+          amount: amount * 100, // Mercury expects amount in cents
+          paymentMethod: 'ach',
+          note: `Withdrawal for ${profile.full_name} - ${txnId}`,
+        }),
+      }
+    )
+
+    if (!response.ok) {
+      const errorData = await response.text()
+      console.error('Mercury API error:', errorData)
+
+      // Rollback transaction on error
+      await supabase.from('txns').delete().eq('id', txnId)
+
+      return { success: false, error: `Mercury API error: ${response.status}` }
+    }
+
+    const data = await response.json()
+
+    // Store Mercury transaction ID
+    await supabase
+      .from('stripe_txns') // Reusing this table for now, could create mercury_txns later
+      .insert({
+        session_id: data.id || data.transactionId || 'mercury_' + txnId,
+        customer_id: user.id,
+        amount: amount,
+        txn_id: txnId,
+      })
+
+    revalidatePath('/withdraw-mercury')
+    return { success: true, transactionId: txnId }
+  } catch (error) {
+    console.error('Error processing withdrawal:', error)
+
+    // Attempt to rollback transaction
+    await supabase.from('txns').delete().eq('id', txnId)
+
+    return { success: false, error: 'Failed to process withdrawal' }
   }
 }

--- a/app/withdraw-mercury/actions.ts
+++ b/app/withdraw-mercury/actions.ts
@@ -169,6 +169,14 @@ export async function withdrawViaMercury(
     return { success: false, error: `Mercury API error: ${response.status}` }
   }
 
-  revalidatePath('/withdraw-mercury')
+  const data = await response.json()
+
+  await supabase.from('stripe_txns').insert({
+    session_id: `mercury_${data.id ?? txnId}`,
+    customer_id: user.id,
+    amount,
+    txn_id: txnId,
+  })
+
   return { success: true, transactionId: txnId }
 }

--- a/app/withdraw-mercury/actions.ts
+++ b/app/withdraw-mercury/actions.ts
@@ -7,16 +7,23 @@ import { getTxnAndProjectsByUser } from '@/db/txn'
 import { getBidsByUser } from '@/db/bid'
 import { calculateCashBalance } from '@/utils/math'
 
-export type ElectronicAccountType =
-  | 'businessChecking'
-  | 'businessSavings'
-  | 'personalChecking'
-  | 'personalSavings'
+const MERCURY_API = 'https://api.mercury.com/api/v1'
+
+function mercuryHeaders() {
+  return {
+    Authorization: `Bearer ${process.env.MERCURY_API_KEY}`,
+    'Content-Type': 'application/json',
+  }
+}
 
 export type BankAccountInfo = {
   accountNumber: string
   routingNumber: string
-  electronicAccountType: ElectronicAccountType
+  electronicAccountType:
+    | 'personalChecking'
+    | 'personalSavings'
+    | 'businessChecking'
+    | 'businessSavings'
   address: {
     address1: string
     address2?: string
@@ -27,282 +34,140 @@ export type BankAccountInfo = {
   }
 }
 
-export type CreateRecipientResult =
-  | { success: true; recipientId: string }
+type ActionResult<T = {}> =
+  | ({ success: true } & T)
   | { success: false; error: string }
 
 export async function createMercuryRecipient(
-  // userId: string,
   bankInfo: BankAccountInfo
-): Promise<CreateRecipientResult> {
+): Promise<ActionResult<{ recipientId: string }>> {
   const supabase = await createServerSupabaseClient()
   const user = await getUser(supabase)
-  const email = user?.email
-  console.log('email', email)
-  if (!user || !user.id || !user.email) {
-    return { success: false, error: 'User, or id, or email not found' }
-  }
+  if (!user?.email) return { success: false, error: 'Not logged in' }
 
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile } = await supabase
     .from('profiles')
-    .select('id, full_name, mercury_recipient_id')
+    .select('full_name, mercury_recipient_id')
     .eq('id', user.id)
     .single()
 
-  if (profileError || !profile) {
-    return { success: false, error: 'Profile not found' }
-  }
-
+  if (!profile) return { success: false, error: 'Profile not found' }
   if (profile.mercury_recipient_id) {
-    return {
-      success: false,
-      error: 'Mercury recipient already exists for this user',
-    }
+    return { success: false, error: 'Bank account already connected' }
   }
 
-  const apiKey = process.env.MERCURY_API_KEY
-  if (!apiKey) {
-    return { success: false, error: 'Mercury API key not configured' }
+  const response = await fetch(`${MERCURY_API}/recipients`, {
+    method: 'POST',
+    headers: mercuryHeaders(),
+    body: JSON.stringify({
+      name: profile.full_name,
+      emails: [user.email],
+      electronicRoutingInfo: bankInfo,
+    }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    console.error('Mercury create recipient error:', text)
+    return { success: false, error: `Mercury API error: ${response.status}` }
   }
 
-  try {
-    const response = await fetch('https://api.mercury.com/api/v1/recipients', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        name: profile.full_name,
-        // electronicRoutingInfo: {
-        //   accountNumber: bankInfo.accountNumber,
-        //   routingNumber: bankInfo.routingNumber,
-        //   electronicAccountType: bankInfo.electronicAccountType,
-        //   address: {
-        //     address1: bankInfo.address.address1,
-        //     address2: bankInfo.address.address2 || null,
-        //     city: bankInfo.address.city,
-        //     region: bankInfo.address.region,
-        //     postalCode: bankInfo.address.postalCode,
-        //     country: bankInfo.address.country,
-        //   },
-        // },
-        electronicRoutingInfo: bankInfo,
-        contactEmail: email,
-        emails: [email],
-      }),
-    })
+  const { id: recipientId } = await response.json()
 
-    if (!response.ok) {
-      const errorData = await response.text()
-      console.error('Mercury API error:', errorData)
-      return {
-        success: false,
-        error: `Mercury API error: ${response.status} ${errorData}`,
-      }
-    }
-
-    const data = await response.json()
-    const recipientId = data.id
-
-    const { error: updateError } = await supabase
-      .from('profiles')
-      .update({ mercury_recipient_id: recipientId })
-      .eq('id', user.id)
-
-    if (updateError) {
-      console.error('Failed to update profile with recipient ID:', updateError)
-      return { success: false, error: 'Failed to save recipient ID' }
-    }
-
-    revalidatePath('/withdraw-mercury')
-    return { success: true, recipientId }
-  } catch (error) {
-    console.error('Error creating Mercury recipient:', error)
-    return { success: false, error: 'Failed to create Mercury recipient' }
-  }
-}
-
-export async function getMercuryRecipient(userId: string) {
-  const supabase = await createServerSupabaseClient()
-
-  const { data: profile, error } = await supabase
+  const { error } = await supabase
     .from('profiles')
-    .select('mercury_recipient_id, accreditation_status')
-    .eq('id', userId)
-    .single()
+    .update({ mercury_recipient_id: recipientId })
+    .eq('id', user.id)
 
-  if (error || !profile) {
-    return null
+  if (error) {
+    console.error('Failed to save recipient ID:', error)
+    return { success: false, error: 'Failed to save recipient ID' }
   }
 
-  if (!profile.mercury_recipient_id) {
-    return null
-  }
-
-  const apiKey = process.env.MERCURY_API_KEY
-  if (!apiKey) {
-    return null
-  }
-
-  try {
-    const response = await fetch(
-      `https://api.mercury.com/api/v1/recipients/${profile.mercury_recipient_id}`,
-      {
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-        },
-      }
-    )
-
-    if (!response.ok) {
-      return null
-    }
-
-    const data = await response.json()
-
-    // Also calculate the user's withdrawable balance
-    const txns = await getTxnAndProjectsByUser(supabase, userId)
-    const bids = await getBidsByUser(supabase, userId)
-    const withdrawBalance = calculateCashBalance(
-      txns,
-      bids,
-      userId,
-      profile.accreditation_status
-    )
-
-    return {
-      id: data.id,
-      name: data.name,
-      accountLastFour: data.electronicRoutingInfo?.accountNumber?.slice(-4),
-      electronicAccountType: data.electronicRoutingInfo?.electronicAccountType,
-      withdrawBalance,
-    }
-  } catch (error) {
-    console.error('Error fetching Mercury recipient:', error)
-    return null
-  }
+  revalidatePath('/withdraw-mercury')
+  return { success: true, recipientId }
 }
-
-export type WithdrawResult =
-  | { success: true; transactionId: string }
-  | { success: false; error: string }
 
 export async function withdrawViaMercury(
   amount: number
-): Promise<WithdrawResult> {
+): Promise<ActionResult<{ transactionId: string }>> {
   const supabase = await createServerSupabaseClient()
   const user = await getUser(supabase)
+  if (!user) return { success: false, error: 'Not logged in' }
 
-  if (!user || !user.id) {
-    return { success: false, error: 'User not found' }
-  }
-
-  // Get user's Mercury recipient ID and profile info
-  const { data: profile, error: profileError } = await supabase
+  const { data: profile } = await supabase
     .from('profiles')
     .select('mercury_recipient_id, full_name, accreditation_status')
     .eq('id', user.id)
     .single()
 
-  if (profileError || !profile || !profile.mercury_recipient_id) {
-    return {
-      success: false,
-      error:
-        'No Mercury recipient found. Please connect your bank account first.',
-    }
+  if (!profile?.mercury_recipient_id) {
+    return { success: false, error: 'No bank account connected' }
   }
 
-  // Get user's balance using the same logic as stripe-connect-withdraw
-  const txns = await getTxnAndProjectsByUser(supabase, user.id)
-  const bids = await getBidsByUser(supabase, user.id)
-  const withdrawBalance = calculateCashBalance(
+  // Verify balance
+  const [txns, bids] = await Promise.all([
+    getTxnAndProjectsByUser(supabase, user.id),
+    getBidsByUser(supabase, user.id),
+  ])
+  const balance = calculateCashBalance(
     txns,
     bids,
     user.id,
     profile.accreditation_status
   )
 
-  if (amount > withdrawBalance) {
-    return { success: false, error: `Insufficient balance. Available balance: $${withdrawBalance.toFixed(2)}` }
+  if (amount <= 0 || amount > balance) {
+    return {
+      success: false,
+      error: `Invalid amount. Available: $${balance.toFixed(2)}`,
+    }
   }
 
-  const apiKey = process.env.MERCURY_API_KEY
   const accountId = process.env.MERCURY_ACCOUNT_ID
-
-  if (!apiKey || !accountId) {
-    return { success: false, error: 'Mercury configuration missing' }
+  if (!accountId) {
+    return { success: false, error: 'Mercury account not configured' }
   }
 
-  // Create transaction ID
   const txnId = crypto.randomUUID()
 
-  try {
-    // Create transaction record first
-    const { error: insertError } = await supabase.from('txns').insert({
-      id: txnId,
-      from_id: user.id,
-      to_id: process.env.NEXT_PUBLIC_PROD_BANK_ID ?? 'bank',
-      amount: amount,
-      token: 'USD',
-      type: 'withdraw',
-      project: null,
-    })
-
-    if (insertError) {
-      console.error('Failed to create transaction:', insertError)
-      return { success: false, error: 'Failed to create transaction record' }
-    }
-
-    // Send money via Mercury API
-    const response = await fetch(
-      'https://api.mercury.com/api/v1/account/request-send-money',
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          accountId: accountId,
-          recipientId: profile.mercury_recipient_id,
-          amount: amount * 100, // Mercury expects amount in cents
-          paymentMethod: 'ach',
-          note: `Withdrawal for ${profile.full_name} - ${txnId}`,
-        }),
-      }
-    )
-
-    if (!response.ok) {
-      const errorData = await response.text()
-      console.error('Mercury API error:', errorData)
-
-      // Rollback transaction on error
-      await supabase.from('txns').delete().eq('id', txnId)
-
-      return { success: false, error: `Mercury API error: ${response.status}` }
-    }
-
-    const data = await response.json()
-
-    // Store Mercury transaction ID
-    await supabase
-      .from('stripe_txns') // Reusing this table for now, could create mercury_txns later
-      .insert({
-        session_id: data.id || data.transactionId || 'mercury_' + txnId,
-        customer_id: user.id,
-        amount: amount,
-        txn_id: txnId,
-      })
-
-    revalidatePath('/withdraw-mercury')
-    return { success: true, transactionId: txnId }
-  } catch (error) {
-    console.error('Error processing withdrawal:', error)
-
-    // Attempt to rollback transaction
-    await supabase.from('txns').delete().eq('id', txnId)
-
-    return { success: false, error: 'Failed to process withdrawal' }
+  // Record the withdrawal txn in our DB
+  const { error: insertError } = await supabase.from('txns').insert({
+    id: txnId,
+    from_id: user.id,
+    to_id: process.env.NEXT_PUBLIC_PROD_BANK_ID ?? '',
+    amount,
+    token: 'USD',
+    type: 'withdraw',
+  })
+  if (insertError) {
+    console.error('Failed to create txn:', insertError)
+    return { success: false, error: 'Failed to record transaction' }
   }
+
+  // Request Mercury to send the money
+  const response = await fetch(
+    `${MERCURY_API}/account/${accountId}/request-send-money`,
+    {
+      method: 'POST',
+      headers: mercuryHeaders(),
+      body: JSON.stringify({
+        recipientId: profile.mercury_recipient_id,
+        amount,
+        paymentMethod: 'ach',
+        note: `Manifund withdrawal for ${profile.full_name} (${txnId})`,
+      }),
+    }
+  )
+
+  if (!response.ok) {
+    const text = await response.text()
+    console.error('Mercury send money error:', text)
+    // Roll back the txn record
+    await supabase.from('txns').delete().eq('id', txnId)
+    return { success: false, error: `Mercury API error: ${response.status}` }
+  }
+
+  revalidatePath('/withdraw-mercury')
+  return { success: true, transactionId: txnId }
 }

--- a/app/withdraw-mercury/actions.ts
+++ b/app/withdraw-mercury/actions.ts
@@ -1,0 +1,134 @@
+'use server'
+
+import { createServerSupabaseClient } from '@/db/supabase-server'
+import { revalidatePath } from 'next/cache'
+
+export type BankAccountInfo = {
+  accountNumber: string
+  routingNumber: string
+  accountType: 'checking' | 'savings'
+  bankName: string
+}
+
+export type CreateRecipientResult =
+  | { success: true; recipientId: string }
+  | { success: false; error: string }
+
+export async function createMercuryRecipient(
+  userId: string,
+  bankInfo: BankAccountInfo
+): Promise<CreateRecipientResult> {
+  const supabase = await createServerSupabaseClient()
+
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .select('id, full_name, mercury_recipient_id')
+    .eq('id', userId)
+    .single()
+
+  if (profileError || !profile) {
+    return { success: false, error: 'Profile not found' }
+  }
+
+  if (profile.mercury_recipient_id) {
+    return { success: false, error: 'Mercury recipient already exists for this user' }
+  }
+
+  const apiKey = process.env.MERCURY_API_KEY
+  if (!apiKey) {
+    return { success: false, error: 'Mercury API key not configured' }
+  }
+
+  try {
+    const response = await fetch('https://api.mercury.com/api/v1/recipients', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: profile.full_name,
+        electronicRoutingInfo: {
+          accountNumber: bankInfo.accountNumber,
+          routingNumber: bankInfo.routingNumber,
+          bankAccountType: bankInfo.accountType,
+          electronicAccountType: 'businessChecking',
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      const errorData = await response.text()
+      console.error('Mercury API error:', errorData)
+      return { success: false, error: `Mercury API error: ${response.status}` }
+    }
+
+    const data = await response.json()
+    const recipientId = data.id
+
+    const { error: updateError } = await supabase
+      .from('profiles')
+      .update({ mercury_recipient_id: recipientId })
+      .eq('id', userId)
+
+    if (updateError) {
+      console.error('Failed to update profile with recipient ID:', updateError)
+      return { success: false, error: 'Failed to save recipient ID' }
+    }
+
+    revalidatePath('/withdraw-mercury')
+    return { success: true, recipientId }
+  } catch (error) {
+    console.error('Error creating Mercury recipient:', error)
+    return { success: false, error: 'Failed to create Mercury recipient' }
+  }
+}
+
+export async function getMercuryRecipient(userId: string) {
+  const supabase = await createServerSupabaseClient()
+
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('mercury_recipient_id')
+    .eq('id', userId)
+    .single()
+
+  if (error || !profile) {
+    return null
+  }
+
+  if (!profile.mercury_recipient_id) {
+    return null
+  }
+
+  const apiKey = process.env.MERCURY_API_KEY
+  if (!apiKey) {
+    return null
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.mercury.com/api/v1/recipients/${profile.mercury_recipient_id}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+        },
+      }
+    )
+
+    if (!response.ok) {
+      return null
+    }
+
+    const data = await response.json()
+    return {
+      id: data.id,
+      name: data.name,
+      accountLastFour: data.electronicRoutingInfo?.accountNumber?.slice(-4),
+      bankAccountType: data.electronicRoutingInfo?.bankAccountType,
+    }
+  } catch (error) {
+    console.error('Error fetching Mercury recipient:', error)
+    return null
+  }
+}

--- a/app/withdraw-mercury/actions.ts
+++ b/app/withdraw-mercury/actions.ts
@@ -144,7 +144,7 @@ export async function getMercuryRecipient(userId: string) {
 
   try {
     const response = await fetch(
-      `https://api.mercury.com/api/v1/recipients/${profile.mercury_recipient_id}`,
+      `https://api.mercury.com/api/v1/recipient/${profile.mercury_recipient_id}`,
       {
         headers: {
           Authorization: `Bearer ${apiKey}`,

--- a/app/withdraw-mercury/international-wire-form.tsx
+++ b/app/withdraw-mercury/international-wire-form.tsx
@@ -1,0 +1,396 @@
+import { Input } from '@/components/input'
+import { Col } from '@/components/layout/col'
+import { Row } from '@/components/layout/row'
+import { InternationalWireInfo } from './actions'
+
+function Label(props: { htmlFor: string; children: React.ReactNode }) {
+  return (
+    <label
+      htmlFor={props.htmlFor}
+      className="mb-1 block text-sm font-medium text-gray-700"
+    >
+      {props.children}
+    </label>
+  )
+}
+
+const COUNTRY_SPECIFIC_FIELDS: Record<
+  string,
+  { label: string; key: string; placeholder: string }[]
+> = {
+  IN: [{ label: 'IFSC Code', key: 'ifscCode', placeholder: 'e.g. SBIN0001234' }],
+  AU: [{ label: 'BSB Number', key: 'bsbNumber', placeholder: '6 digits' }],
+  CA: [
+    { label: 'Bank Code', key: 'bankCode', placeholder: '3 digits' },
+    { label: 'Transit Number', key: 'transitNumber', placeholder: '5 digits' },
+  ],
+  HK: [{ label: 'Bank Code', key: 'bankCode', placeholder: '3 digits' }],
+  SG: [{ label: 'Bank Code', key: 'bankCode', placeholder: 'Bank code' }],
+  ZA: [{ label: 'Branch Code', key: 'branchCode', placeholder: '6 digits' }],
+}
+
+const SUPPORTED_COUNTRIES = [
+  { code: '', label: 'None' },
+  { code: 'IN', label: 'India' },
+  { code: 'AU', label: 'Australia' },
+  { code: 'CA', label: 'Canada' },
+  { code: 'HK', label: 'Hong Kong' },
+  { code: 'SG', label: 'Singapore' },
+  { code: 'ZA', label: 'South Africa' },
+]
+
+export function useInternationalWireState() {
+  const [wireInfo, setWireInfo] = useState<InternationalWireInfo>({
+    swiftCode: '',
+    iban: '',
+    address: {
+      address1: '',
+      city: '',
+      region: '',
+      postalCode: '',
+      country: '',
+    },
+    bankDetails: {
+      bankName: '',
+      bankCountry: '',
+      cityState: '',
+    },
+  })
+  const [countrySpecificCountry, setCountrySpecificCountry] = useState('')
+  const [showCorrespondent, setShowCorrespondent] = useState(false)
+
+  const updateWire = (patch: Partial<InternationalWireInfo>) =>
+    setWireInfo((prev) => ({ ...prev, ...patch }))
+  const updateAddress = (patch: Partial<InternationalWireInfo['address']>) =>
+    setWireInfo((prev) => ({
+      ...prev,
+      address: { ...prev.address, ...patch },
+    }))
+  const updateBankDetails = (
+    patch: Partial<InternationalWireInfo['bankDetails']>
+  ) =>
+    setWireInfo((prev) => ({
+      ...prev,
+      bankDetails: { ...prev.bankDetails, ...patch },
+    }))
+  const updateCorrespondent = (
+    patch: Partial<NonNullable<InternationalWireInfo['correspondentInfo']>>
+  ) =>
+    setWireInfo((prev) => ({
+      ...prev,
+      correspondentInfo: { ...prev.correspondentInfo, bankName: '', ...patch },
+    }))
+  const updateCountrySpecific = (key: string, value: string) =>
+    setWireInfo((prev) => ({
+      ...prev,
+      countrySpecific: { ...prev.countrySpecific, [key]: value },
+    }))
+
+  return {
+    wireInfo,
+    countrySpecificCountry,
+    setCountrySpecificCountry,
+    showCorrespondent,
+    setShowCorrespondent,
+    updateWire,
+    updateAddress,
+    updateBankDetails,
+    updateCorrespondent,
+    updateCountrySpecific,
+  }
+}
+
+// Need to import useState
+import { useState } from 'react'
+
+export function InternationalWireFields(props: {
+  wireState: ReturnType<typeof useInternationalWireState>
+  disabled: boolean
+}) {
+  const {
+    wireInfo,
+    countrySpecificCountry,
+    setCountrySpecificCountry,
+    showCorrespondent,
+    setShowCorrespondent,
+    updateWire,
+    updateAddress,
+    updateBankDetails,
+    updateCorrespondent,
+    updateCountrySpecific,
+  } = props.wireState
+  const disabled = props.disabled
+
+  const countryFields = countrySpecificCountry
+    ? COUNTRY_SPECIFIC_FIELDS[countrySpecificCountry]
+    : undefined
+
+  return (
+    <Col className="gap-5">
+      {/* SWIFT & IBAN */}
+      <Row className="gap-3">
+        <div className="flex-1">
+          <Label htmlFor="swiftCode">SWIFT / BIC Code</Label>
+          <Input
+            id="swiftCode"
+            placeholder="e.g. CHASUS33"
+            maxLength={11}
+            value={wireInfo.swiftCode}
+            onChange={(e) =>
+              updateWire({ swiftCode: e.target.value.toUpperCase() })
+            }
+            disabled={disabled}
+            required
+            className="w-full"
+          />
+        </div>
+        <div className="flex-1">
+          <Label htmlFor="iban">IBAN / Account Number</Label>
+          <Input
+            id="iban"
+            placeholder="e.g. GB29 NWBK 6016 1331 9268 19"
+            value={wireInfo.iban}
+            onChange={(e) => updateWire({ iban: e.target.value })}
+            disabled={disabled}
+            required
+            className="w-full"
+          />
+        </div>
+      </Row>
+
+      {/* Bank Details */}
+      <div className="border-t pt-4">
+        <h3 className="mb-3 text-sm font-semibold text-gray-900">
+          Bank Details
+        </h3>
+        <Col className="gap-3">
+          <div>
+            <Label htmlFor="bankName">Bank Name</Label>
+            <Input
+              id="bankName"
+              placeholder="e.g. HSBC Holdings"
+              value={wireInfo.bankDetails.bankName}
+              onChange={(e) => updateBankDetails({ bankName: e.target.value })}
+              disabled={disabled}
+              required
+              className="w-full"
+            />
+          </div>
+          <Row className="gap-3">
+            <div className="flex-1">
+              <Label htmlFor="bankCityState">City / State</Label>
+              <Input
+                id="bankCityState"
+                placeholder="London"
+                value={wireInfo.bankDetails.cityState}
+                onChange={(e) =>
+                  updateBankDetails({ cityState: e.target.value })
+                }
+                disabled={disabled}
+                required
+                className="w-full"
+              />
+            </div>
+            <div className="w-32">
+              <Label htmlFor="bankCountry">Country Code</Label>
+              <Input
+                id="bankCountry"
+                placeholder="GB"
+                maxLength={2}
+                value={wireInfo.bankDetails.bankCountry}
+                onChange={(e) =>
+                  updateBankDetails({
+                    bankCountry: e.target.value.toUpperCase(),
+                  })
+                }
+                disabled={disabled}
+                required
+                className="w-full"
+              />
+            </div>
+          </Row>
+        </Col>
+      </div>
+
+      {/* Recipient Address */}
+      <div className="border-t pt-4">
+        <h3 className="mb-3 text-sm font-semibold text-gray-900">
+          Recipient Address
+        </h3>
+        <Col className="gap-3">
+          <div>
+            <Label htmlFor="intlAddress1">Street Address</Label>
+            <Input
+              id="intlAddress1"
+              placeholder="123 Main St"
+              value={wireInfo.address.address1}
+              onChange={(e) => updateAddress({ address1: e.target.value })}
+              disabled={disabled}
+              required
+              className="w-full"
+            />
+          </div>
+          <Row className="gap-3">
+            <div className="flex-1">
+              <Label htmlFor="intlCity">City</Label>
+              <Input
+                id="intlCity"
+                placeholder="City"
+                value={wireInfo.address.city}
+                onChange={(e) => updateAddress({ city: e.target.value })}
+                disabled={disabled}
+                required
+                className="w-full"
+              />
+            </div>
+            <div className="w-32">
+              <Label htmlFor="intlRegion">Region</Label>
+              <Input
+                id="intlRegion"
+                placeholder="State"
+                value={wireInfo.address.region}
+                onChange={(e) => updateAddress({ region: e.target.value })}
+                disabled={disabled}
+                required
+                className="w-full"
+              />
+            </div>
+          </Row>
+          <Row className="gap-3">
+            <div className="flex-1">
+              <Label htmlFor="intlPostalCode">Postal Code</Label>
+              <Input
+                id="intlPostalCode"
+                placeholder="Postal code"
+                value={wireInfo.address.postalCode}
+                onChange={(e) => updateAddress({ postalCode: e.target.value })}
+                disabled={disabled}
+                required
+                className="w-full"
+              />
+            </div>
+            <div className="w-32">
+              <Label htmlFor="intlCountry">Country</Label>
+              <Input
+                id="intlCountry"
+                placeholder="GB"
+                maxLength={2}
+                value={wireInfo.address.country}
+                onChange={(e) =>
+                  updateAddress({ country: e.target.value.toUpperCase() })
+                }
+                disabled={disabled}
+                required
+                className="w-full"
+              />
+            </div>
+          </Row>
+        </Col>
+      </div>
+
+      {/* Country-Specific Fields */}
+      <div className="border-t pt-4">
+        <h3 className="mb-3 text-sm font-semibold text-gray-900">
+          Country-Specific Requirements (Optional)
+        </h3>
+        <div>
+          <Label htmlFor="countrySpecific">Country</Label>
+          <select
+            id="countrySpecific"
+            value={countrySpecificCountry}
+            onChange={(e) => setCountrySpecificCountry(e.target.value)}
+            disabled={disabled}
+            className="h-12 w-full rounded-md border border-gray-300 bg-white px-4 shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+          >
+            {SUPPORTED_COUNTRIES.map((c) => (
+              <option key={c.code} value={c.code}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        {countryFields && (
+          <Col className="mt-3 gap-3">
+            {countryFields.map((field) => (
+              <div key={field.key}>
+                <Label htmlFor={field.key}>{field.label}</Label>
+                <Input
+                  id={field.key}
+                  placeholder={field.placeholder}
+                  value={wireInfo.countrySpecific?.[field.key] ?? ''}
+                  onChange={(e) =>
+                    updateCountrySpecific(field.key, e.target.value)
+                  }
+                  disabled={disabled}
+                  className="w-full"
+                />
+              </div>
+            ))}
+          </Col>
+        )}
+      </div>
+
+      {/* Correspondent Bank (Optional) */}
+      <div className="border-t pt-4">
+        <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={showCorrespondent}
+            onChange={(e) => setShowCorrespondent(e.target.checked)}
+            disabled={disabled}
+          />
+          <span className="font-medium text-gray-700">
+            Add Correspondent / Intermediary Bank
+          </span>
+        </label>
+        {showCorrespondent && (
+          <Col className="mt-3 gap-3">
+            <div>
+              <Label htmlFor="corrBankName">Correspondent Bank Name</Label>
+              <Input
+                id="corrBankName"
+                placeholder="Bank name"
+                value={wireInfo.correspondentInfo?.bankName ?? ''}
+                onChange={(e) =>
+                  updateCorrespondent({ bankName: e.target.value })
+                }
+                disabled={disabled}
+                className="w-full"
+              />
+            </div>
+            <Row className="gap-3">
+              <div className="flex-1">
+                <Label htmlFor="corrRouting">Routing Number</Label>
+                <Input
+                  id="corrRouting"
+                  placeholder="Optional"
+                  value={wireInfo.correspondentInfo?.routingNumber ?? ''}
+                  onChange={(e) =>
+                    updateCorrespondent({ routingNumber: e.target.value })
+                  }
+                  disabled={disabled}
+                  className="w-full"
+                />
+              </div>
+              <div className="flex-1">
+                <Label htmlFor="corrSwift">SWIFT Code</Label>
+                <Input
+                  id="corrSwift"
+                  placeholder="Optional"
+                  value={wireInfo.correspondentInfo?.swiftCode ?? ''}
+                  onChange={(e) =>
+                    updateCorrespondent({
+                      swiftCode: e.target.value.toUpperCase(),
+                    })
+                  }
+                  disabled={disabled}
+                  className="w-full"
+                />
+              </div>
+            </Row>
+          </Col>
+        )}
+      </div>
+    </Col>
+  )
+}

--- a/app/withdraw-mercury/page.tsx
+++ b/app/withdraw-mercury/page.tsx
@@ -56,7 +56,7 @@ export default function WithdrawMercuryPage() {
       return
     }
 
-    loadExistingRecipient()
+    void loadExistingRecipient()
   }, [session])
 
   const loadExistingRecipient = async () => {
@@ -164,7 +164,8 @@ export default function WithdrawMercuryPage() {
             </Col>
 
             <div className="text-center text-sm text-gray-500">
-              To update your bank information, please contact support.
+              To update your bank information, please contact
+              austin@manifund.org.
             </div>
           </Col>
         </Card>

--- a/app/withdraw-mercury/page.tsx
+++ b/app/withdraw-mercury/page.tsx
@@ -8,8 +8,25 @@ import { Row } from '@/components/layout/row'
 import { Input } from '@/components/input'
 import { Button } from '@/components/button'
 import { useSupabase } from '@/db/supabase-provider'
-import { createMercuryRecipient, getMercuryRecipient, BankAccountInfo } from './actions'
+import {
+  createMercuryRecipient,
+  getMercuryRecipient,
+  BankAccountInfo,
+  ElectronicAccountType,
+} from './actions'
 import { CheckCircleIcon } from '@heroicons/react/20/solid'
+
+const ACCOUNT_TYPE_OPTIONS: { value: ElectronicAccountType; label: string }[] =
+  [
+    { value: 'personalChecking', label: 'Personal Checking' },
+    { value: 'personalSavings', label: 'Personal Savings' },
+    { value: 'businessChecking', label: 'Business Checking' },
+    { value: 'businessSavings', label: 'Business Savings' },
+  ]
+
+function formatAccountType(type: ElectronicAccountType | undefined): string {
+  return ACCOUNT_TYPE_OPTIONS.find((o) => o.value === type)?.label || 'Unknown'
+}
 
 export default function WithdrawMercuryPage() {
   const { session } = useSupabase()
@@ -22,8 +39,15 @@ export default function WithdrawMercuryPage() {
   const [bankInfo, setBankInfo] = useState<BankAccountInfo>({
     accountNumber: '',
     routingNumber: '',
-    accountType: 'checking',
-    bankName: '',
+    electronicAccountType: 'personalChecking',
+    address: {
+      address1: '',
+      address2: '',
+      city: '',
+      region: '',
+      postalCode: '',
+      country: 'US',
+    },
   })
 
   useEffect(() => {
@@ -60,14 +84,22 @@ export default function WithdrawMercuryPage() {
       return
     }
 
-    if (!bankInfo.accountNumber || !bankInfo.routingNumber || !bankInfo.bankName) {
+    if (
+      !bankInfo.accountNumber ||
+      !bankInfo.routingNumber ||
+      !bankInfo.address.address1 ||
+      !bankInfo.address.city ||
+      !bankInfo.address.region ||
+      !bankInfo.address.postalCode ||
+      !bankInfo.address.country
+    ) {
       setError('Please fill in all required fields')
       return
     }
 
     setSubmitting(true)
     try {
-      const result = await createMercuryRecipient(session.user.id, bankInfo)
+      const result = await createMercuryRecipient(bankInfo)
 
       if (result.success) {
         await loadExistingRecipient()
@@ -94,19 +126,23 @@ export default function WithdrawMercuryPage() {
 
   if (existingRecipient) {
     return (
-      <Col className="mx-auto max-w-2xl p-6">
+      <Col className="mx-auto p-6">
         <Card className="p-8">
           <Col className="gap-6">
             <div className="text-center">
               <CheckCircleIcon className="mx-auto h-12 w-12 text-emerald-500" />
-              <h1 className="mt-4 text-2xl font-bold">Bank Account Connected</h1>
+              <h1 className="mt-4 text-2xl font-bold">
+                Bank Account Connected
+              </h1>
               <p className="mt-2 text-gray-600">
                 Your bank account is already connected for withdrawals.
               </p>
             </div>
 
             <Col className="gap-4 rounded-lg bg-gray-50 p-6">
-              <h2 className="font-semibold text-gray-900">Account Information</h2>
+              <h2 className="font-semibold text-gray-900">
+                Account Information
+              </h2>
               <div className="space-y-2 text-sm">
                 <Row className="justify-between">
                   <span className="text-gray-600">Account Name:</span>
@@ -114,11 +150,15 @@ export default function WithdrawMercuryPage() {
                 </Row>
                 <Row className="justify-between">
                   <span className="text-gray-600">Account Type:</span>
-                  <span className="font-medium capitalize">{existingRecipient.bankAccountType || 'Checking'}</span>
+                  <span className="font-medium">
+                    {formatAccountType(existingRecipient.electronicAccountType)}
+                  </span>
                 </Row>
                 <Row className="justify-between">
                   <span className="text-gray-600">Account Number:</span>
-                  <span className="font-medium">****{existingRecipient.accountLastFour}</span>
+                  <span className="font-medium">
+                    ****{existingRecipient.accountLastFour}
+                  </span>
                 </Row>
               </div>
             </Col>
@@ -134,128 +174,290 @@ export default function WithdrawMercuryPage() {
 
   return (
     <Col className="mx-auto max-w-2xl p-6">
-      <Card className="p-8">
-        <form onSubmit={handleSubmit}>
-          <Col className="gap-6">
+      <form onSubmit={handleSubmit}>
+        <Col className="gap-6">
+          <div>
+            <h1 className="text-2xl font-bold">Connect Your Bank Account</h1>
+            <p className="mt-2 text-gray-600">
+              Enter your US bank account information to enable withdrawals.
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-rose-50 p-4 text-sm text-rose-800">
+              {error}
+            </div>
+          )}
+
+          <Col className="gap-4">
             <div>
-              <h1 className="text-2xl font-bold">Connect Your Bank Account</h1>
-              <p className="mt-2 text-gray-600">
-                Enter your US bank account information to enable withdrawals.
+              <label
+                htmlFor="routingNumber"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Routing Number *
+              </label>
+              <Input
+                id="routingNumber"
+                type="text"
+                placeholder="9 digits"
+                maxLength={9}
+                pattern="[0-9]{9}"
+                value={bankInfo.routingNumber}
+                onChange={(e) =>
+                  setBankInfo({
+                    ...bankInfo,
+                    routingNumber: e.target.value.replace(/\D/g, ''),
+                  })
+                }
+                disabled={submitting}
+                required
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                The 9-digit routing number for your bank
               </p>
             </div>
 
-            {error && (
-              <div className="rounded-md bg-rose-50 p-4 text-sm text-rose-800">
-                {error}
-              </div>
-            )}
-
-            <Col className="gap-4">
-              <div>
-                <label htmlFor="bankName" className="mb-1 block text-sm font-medium text-gray-700">
-                  Bank Name *
-                </label>
-                <Input
-                  id="bankName"
-                  type="text"
-                  placeholder="e.g., Chase Bank"
-                  value={bankInfo.bankName}
-                  onChange={(e) => setBankInfo({ ...bankInfo, bankName: e.target.value })}
-                  disabled={submitting}
-                  required
-                />
-              </div>
-
-              <div>
-                <label htmlFor="routingNumber" className="mb-1 block text-sm font-medium text-gray-700">
-                  Routing Number *
-                </label>
-                <Input
-                  id="routingNumber"
-                  type="text"
-                  placeholder="9 digits"
-                  maxLength={9}
-                  pattern="[0-9]{9}"
-                  value={bankInfo.routingNumber}
-                  onChange={(e) => setBankInfo({ ...bankInfo, routingNumber: e.target.value.replace(/\D/g, '') })}
-                  disabled={submitting}
-                  required
-                />
-                <p className="mt-1 text-xs text-gray-500">
-                  The 9-digit routing number for your bank
-                </p>
-              </div>
-
-              <div>
-                <label htmlFor="accountNumber" className="mb-1 block text-sm font-medium text-gray-700">
-                  Account Number *
-                </label>
-                <Input
-                  id="accountNumber"
-                  type="text"
-                  placeholder="Your account number"
-                  value={bankInfo.accountNumber}
-                  onChange={(e) => setBankInfo({ ...bankInfo, accountNumber: e.target.value.replace(/\D/g, '') })}
-                  disabled={submitting}
-                  required
-                />
-              </div>
-
-              <div>
-                <label className="mb-1 block text-sm font-medium text-gray-700">
-                  Account Type *
-                </label>
-                <Row className="gap-4">
-                  <label className="flex items-center">
-                    <input
-                      type="radio"
-                      name="accountType"
-                      value="checking"
-                      checked={bankInfo.accountType === 'checking'}
-                      onChange={(e) => setBankInfo({ ...bankInfo, accountType: e.target.value as 'checking' | 'savings' })}
-                      className="mr-2"
-                      disabled={submitting}
-                    />
-                    <span className="text-sm">Checking</span>
-                  </label>
-                  <label className="flex items-center">
-                    <input
-                      type="radio"
-                      name="accountType"
-                      value="savings"
-                      checked={bankInfo.accountType === 'savings'}
-                      onChange={(e) => setBankInfo({ ...bankInfo, accountType: e.target.value as 'checking' | 'savings' })}
-                      className="mr-2"
-                      disabled={submitting}
-                    />
-                    <span className="text-sm">Savings</span>
-                  </label>
-                </Row>
-              </div>
-            </Col>
-
-            <div className="rounded-lg bg-blue-50 p-4 text-sm text-blue-800">
-              <p className="font-semibold">Important:</p>
-              <ul className="mt-1 list-inside list-disc space-y-1">
-                <li>Only US bank accounts are currently supported</li>
-                <li>Your information is securely transmitted and stored</li>
-                <li>Bank verification may take 1-2 business days</li>
-              </ul>
+            <div>
+              <label
+                htmlFor="accountNumber"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Account Number *
+              </label>
+              <Input
+                id="accountNumber"
+                type="text"
+                placeholder="Your account number"
+                value={bankInfo.accountNumber}
+                onChange={(e) =>
+                  setBankInfo({
+                    ...bankInfo,
+                    accountNumber: e.target.value.replace(/\D/g, ''),
+                  })
+                }
+                disabled={submitting}
+                required
+              />
             </div>
 
-            <Button
-              type="submit"
-              size="lg"
-              color="orange"
-              className="w-full"
-              disabled={submitting}
-              loading={submitting}
-            >
-              {submitting ? 'Connecting...' : 'Connect Bank Account'}
-            </Button>
+            <div>
+              <label
+                htmlFor="accountType"
+                className="mb-1 block text-sm font-medium text-gray-700"
+              >
+                Account Type *
+              </label>
+              <select
+                id="accountType"
+                value={bankInfo.electronicAccountType}
+                onChange={(e) =>
+                  setBankInfo({
+                    ...bankInfo,
+                    electronicAccountType: e.target
+                      .value as ElectronicAccountType,
+                  })
+                }
+                disabled={submitting}
+                className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+              >
+                {ACCOUNT_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="border-t pt-4">
+              <h3 className="mb-3 text-sm font-semibold text-gray-900">
+                Account Holder Address
+              </h3>
+              <Col className="gap-3">
+                <div>
+                  <label
+                    htmlFor="address1"
+                    className="mb-1 block text-sm font-medium text-gray-700"
+                  >
+                    Address Line 1 *
+                  </label>
+                  <Input
+                    id="address1"
+                    type="text"
+                    placeholder="Street address"
+                    value={bankInfo.address.address1}
+                    onChange={(e) =>
+                      setBankInfo({
+                        ...bankInfo,
+                        address: {
+                          ...bankInfo.address,
+                          address1: e.target.value,
+                        },
+                      })
+                    }
+                    disabled={submitting}
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="address2"
+                    className="mb-1 block text-sm font-medium text-gray-700"
+                  >
+                    Address Line 2
+                  </label>
+                  <Input
+                    id="address2"
+                    type="text"
+                    placeholder="Apt, suite, etc. (optional)"
+                    value={bankInfo.address.address2 || ''}
+                    onChange={(e) =>
+                      setBankInfo({
+                        ...bankInfo,
+                        address: {
+                          ...bankInfo.address,
+                          address2: e.target.value,
+                        },
+                      })
+                    }
+                    disabled={submitting}
+                  />
+                </div>
+
+                <Row className="gap-3">
+                  <div className="flex-1">
+                    <label
+                      htmlFor="city"
+                      className="mb-1 block text-sm font-medium text-gray-700"
+                    >
+                      City *
+                    </label>
+                    <Input
+                      id="city"
+                      type="text"
+                      placeholder="City"
+                      value={bankInfo.address.city}
+                      onChange={(e) =>
+                        setBankInfo({
+                          ...bankInfo,
+                          address: {
+                            ...bankInfo.address,
+                            city: e.target.value,
+                          },
+                        })
+                      }
+                      disabled={submitting}
+                      required
+                    />
+                  </div>
+                  <div className="w-24">
+                    <label
+                      htmlFor="region"
+                      className="mb-1 block text-sm font-medium text-gray-700"
+                    >
+                      State *
+                    </label>
+                    <Input
+                      id="region"
+                      type="text"
+                      placeholder="CA"
+                      maxLength={2}
+                      value={bankInfo.address.region}
+                      onChange={(e) =>
+                        setBankInfo({
+                          ...bankInfo,
+                          address: {
+                            ...bankInfo.address,
+                            region: e.target.value.toUpperCase(),
+                          },
+                        })
+                      }
+                      disabled={submitting}
+                      required
+                    />
+                  </div>
+                </Row>
+
+                <Row className="gap-3">
+                  <div className="flex-1">
+                    <label
+                      htmlFor="postalCode"
+                      className="mb-1 block text-sm font-medium text-gray-700"
+                    >
+                      ZIP Code *
+                    </label>
+                    <Input
+                      id="postalCode"
+                      type="text"
+                      placeholder="12345"
+                      maxLength={10}
+                      value={bankInfo.address.postalCode}
+                      onChange={(e) =>
+                        setBankInfo({
+                          ...bankInfo,
+                          address: {
+                            ...bankInfo.address,
+                            postalCode: e.target.value,
+                          },
+                        })
+                      }
+                      disabled={submitting}
+                      required
+                    />
+                  </div>
+                  <div className="w-24">
+                    <label
+                      htmlFor="country"
+                      className="mb-1 block text-sm font-medium text-gray-700"
+                    >
+                      Country *
+                    </label>
+                    <Input
+                      id="country"
+                      type="text"
+                      placeholder="US"
+                      maxLength={2}
+                      value={bankInfo.address.country}
+                      onChange={(e) =>
+                        setBankInfo({
+                          ...bankInfo,
+                          address: {
+                            ...bankInfo.address,
+                            country: e.target.value.toUpperCase(),
+                          },
+                        })
+                      }
+                      disabled={submitting}
+                      required
+                    />
+                  </div>
+                </Row>
+              </Col>
+            </div>
           </Col>
-        </form>
-      </Card>
+
+          <div className="rounded-lg bg-blue-50 p-4 text-sm text-blue-800">
+            <p className="font-semibold">Important:</p>
+            <ul className="mt-1 list-inside list-disc space-y-1">
+              <li>Only US bank accounts are currently supported</li>
+              <li>Your information is securely transmitted and stored</li>
+              <li>Bank verification may take 1-2 business days</li>
+            </ul>
+          </div>
+
+          <Button
+            type="submit"
+            size="lg"
+            color="orange"
+            className="w-full"
+            disabled={submitting}
+            loading={submitting}
+          >
+            {submitting ? 'Connecting...' : 'Connect Bank Account'}
+          </Button>
+        </Col>
+      </form>
     </Col>
   )
 }

--- a/app/withdraw-mercury/page.tsx
+++ b/app/withdraw-mercury/page.tsx
@@ -49,7 +49,7 @@ async function fetchMercuryRecipient(recipientId: string) {
 
   try {
     const res = await fetch(
-      `https://api.mercury.com/api/v1/recipients/${recipientId}`,
+      `https://api.mercury.com/api/v1/recipient/${recipientId}`,
       { headers: { Authorization: `Bearer ${apiKey}` } }
     )
     if (!res.ok) return null

--- a/app/withdraw-mercury/page.tsx
+++ b/app/withdraw-mercury/page.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card } from '@/components/layout/card'
+import { Col } from '@/components/layout/col'
+import { Row } from '@/components/layout/row'
+import { Input } from '@/components/input'
+import { Button } from '@/components/button'
+import { useSupabase } from '@/db/supabase-provider'
+import { createMercuryRecipient, getMercuryRecipient, BankAccountInfo } from './actions'
+import { CheckCircleIcon } from '@heroicons/react/20/solid'
+
+export default function WithdrawMercuryPage() {
+  const { session } = useSupabase()
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [submitting, setSubmitting] = useState(false)
+  const [existingRecipient, setExistingRecipient] = useState<any>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const [bankInfo, setBankInfo] = useState<BankAccountInfo>({
+    accountNumber: '',
+    routingNumber: '',
+    accountType: 'checking',
+    bankName: '',
+  })
+
+  useEffect(() => {
+    if (!session?.user?.id) {
+      router.push('/login')
+      return
+    }
+
+    loadExistingRecipient()
+  }, [session])
+
+  const loadExistingRecipient = async () => {
+    if (!session?.user?.id) return
+
+    setLoading(true)
+    try {
+      const recipient = await getMercuryRecipient(session.user.id)
+      if (recipient) {
+        setExistingRecipient(recipient)
+      }
+    } catch (err) {
+      console.error('Error loading recipient:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!session?.user?.id) {
+      setError('You must be logged in to continue')
+      return
+    }
+
+    if (!bankInfo.accountNumber || !bankInfo.routingNumber || !bankInfo.bankName) {
+      setError('Please fill in all required fields')
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const result = await createMercuryRecipient(session.user.id, bankInfo)
+
+      if (result.success) {
+        await loadExistingRecipient()
+      } else {
+        setError(result.error)
+      }
+    } catch (err) {
+      setError('An unexpected error occurred')
+      console.error('Error creating recipient:', err)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <Col className="mx-auto max-w-2xl p-6">
+        <Card className="p-8">
+          <div className="text-center text-gray-500">Loading...</div>
+        </Card>
+      </Col>
+    )
+  }
+
+  if (existingRecipient) {
+    return (
+      <Col className="mx-auto max-w-2xl p-6">
+        <Card className="p-8">
+          <Col className="gap-6">
+            <div className="text-center">
+              <CheckCircleIcon className="mx-auto h-12 w-12 text-emerald-500" />
+              <h1 className="mt-4 text-2xl font-bold">Bank Account Connected</h1>
+              <p className="mt-2 text-gray-600">
+                Your bank account is already connected for withdrawals.
+              </p>
+            </div>
+
+            <Col className="gap-4 rounded-lg bg-gray-50 p-6">
+              <h2 className="font-semibold text-gray-900">Account Information</h2>
+              <div className="space-y-2 text-sm">
+                <Row className="justify-between">
+                  <span className="text-gray-600">Account Name:</span>
+                  <span className="font-medium">{existingRecipient.name}</span>
+                </Row>
+                <Row className="justify-between">
+                  <span className="text-gray-600">Account Type:</span>
+                  <span className="font-medium capitalize">{existingRecipient.bankAccountType || 'Checking'}</span>
+                </Row>
+                <Row className="justify-between">
+                  <span className="text-gray-600">Account Number:</span>
+                  <span className="font-medium">****{existingRecipient.accountLastFour}</span>
+                </Row>
+              </div>
+            </Col>
+
+            <div className="text-center text-sm text-gray-500">
+              To update your bank information, please contact support.
+            </div>
+          </Col>
+        </Card>
+      </Col>
+    )
+  }
+
+  return (
+    <Col className="mx-auto max-w-2xl p-6">
+      <Card className="p-8">
+        <form onSubmit={handleSubmit}>
+          <Col className="gap-6">
+            <div>
+              <h1 className="text-2xl font-bold">Connect Your Bank Account</h1>
+              <p className="mt-2 text-gray-600">
+                Enter your US bank account information to enable withdrawals.
+              </p>
+            </div>
+
+            {error && (
+              <div className="rounded-md bg-rose-50 p-4 text-sm text-rose-800">
+                {error}
+              </div>
+            )}
+
+            <Col className="gap-4">
+              <div>
+                <label htmlFor="bankName" className="mb-1 block text-sm font-medium text-gray-700">
+                  Bank Name *
+                </label>
+                <Input
+                  id="bankName"
+                  type="text"
+                  placeholder="e.g., Chase Bank"
+                  value={bankInfo.bankName}
+                  onChange={(e) => setBankInfo({ ...bankInfo, bankName: e.target.value })}
+                  disabled={submitting}
+                  required
+                />
+              </div>
+
+              <div>
+                <label htmlFor="routingNumber" className="mb-1 block text-sm font-medium text-gray-700">
+                  Routing Number *
+                </label>
+                <Input
+                  id="routingNumber"
+                  type="text"
+                  placeholder="9 digits"
+                  maxLength={9}
+                  pattern="[0-9]{9}"
+                  value={bankInfo.routingNumber}
+                  onChange={(e) => setBankInfo({ ...bankInfo, routingNumber: e.target.value.replace(/\D/g, '') })}
+                  disabled={submitting}
+                  required
+                />
+                <p className="mt-1 text-xs text-gray-500">
+                  The 9-digit routing number for your bank
+                </p>
+              </div>
+
+              <div>
+                <label htmlFor="accountNumber" className="mb-1 block text-sm font-medium text-gray-700">
+                  Account Number *
+                </label>
+                <Input
+                  id="accountNumber"
+                  type="text"
+                  placeholder="Your account number"
+                  value={bankInfo.accountNumber}
+                  onChange={(e) => setBankInfo({ ...bankInfo, accountNumber: e.target.value.replace(/\D/g, '') })}
+                  disabled={submitting}
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-medium text-gray-700">
+                  Account Type *
+                </label>
+                <Row className="gap-4">
+                  <label className="flex items-center">
+                    <input
+                      type="radio"
+                      name="accountType"
+                      value="checking"
+                      checked={bankInfo.accountType === 'checking'}
+                      onChange={(e) => setBankInfo({ ...bankInfo, accountType: e.target.value as 'checking' | 'savings' })}
+                      className="mr-2"
+                      disabled={submitting}
+                    />
+                    <span className="text-sm">Checking</span>
+                  </label>
+                  <label className="flex items-center">
+                    <input
+                      type="radio"
+                      name="accountType"
+                      value="savings"
+                      checked={bankInfo.accountType === 'savings'}
+                      onChange={(e) => setBankInfo({ ...bankInfo, accountType: e.target.value as 'checking' | 'savings' })}
+                      className="mr-2"
+                      disabled={submitting}
+                    />
+                    <span className="text-sm">Savings</span>
+                  </label>
+                </Row>
+              </div>
+            </Col>
+
+            <div className="rounded-lg bg-blue-50 p-4 text-sm text-blue-800">
+              <p className="font-semibold">Important:</p>
+              <ul className="mt-1 list-inside list-disc space-y-1">
+                <li>Only US bank accounts are currently supported</li>
+                <li>Your information is securely transmitted and stored</li>
+                <li>Bank verification may take 1-2 business days</li>
+              </ul>
+            </div>
+
+            <Button
+              type="submit"
+              size="lg"
+              color="orange"
+              className="w-full"
+              disabled={submitting}
+              loading={submitting}
+            >
+              {submitting ? 'Connecting...' : 'Connect Bank Account'}
+            </Button>
+          </Col>
+        </form>
+      </Card>
+    </Col>
+  )
+}

--- a/app/withdraw-mercury/withdraw-mercury-client.tsx
+++ b/app/withdraw-mercury/withdraw-mercury-client.tsx
@@ -263,9 +263,10 @@ export function WithdrawForm(props: {
   recipientName: string
   accountLastFour: string | undefined
   accountType: string | undefined
-  withdrawBalance: number
+  balance: number
 }) {
-  const { recipientName, accountLastFour, accountType, withdrawBalance } = props
+  const { recipientName, accountLastFour, accountType } = props
+  const [balance, setBalance] = useState(props.balance)
   const [amount, setAmount] = useState('')
   const [withdrawing, setWithdrawing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -290,6 +291,7 @@ export function WithdrawForm(props: {
       const result = await withdrawViaMercury(dollars)
       if (result.success) {
         setSuccess(`Withdrawal of $${dollars.toFixed(2)} submitted.`)
+        setBalance((b) => b - dollars)
         setAmount('')
       } else {
         setError(result.error)
@@ -346,7 +348,7 @@ export function WithdrawForm(props: {
                   Available Balance
                 </span>
                 <span className="text-lg font-bold">
-                  ${withdrawBalance.toFixed(2)}
+                  ${balance.toFixed(2)}
                 </span>
               </Row>
             </div>
@@ -361,8 +363,8 @@ export function WithdrawForm(props: {
                   id="amount"
                   type="number"
                   step="0.01"
-                  min="1"
-                  max={withdrawBalance}
+                  min="100"
+                  max={balance}
                   placeholder="0.00"
                   value={amount}
                   onChange={(e) => setAmount(e.target.value)}

--- a/app/withdraw-mercury/withdraw-mercury-client.tsx
+++ b/app/withdraw-mercury/withdraw-mercury-client.tsx
@@ -1,0 +1,391 @@
+'use client'
+
+import { useState } from 'react'
+import { Card } from '@/components/layout/card'
+import { Col } from '@/components/layout/col'
+import { Row } from '@/components/layout/row'
+import { Input } from '@/components/input'
+import { Button } from '@/components/button'
+import {
+  createMercuryRecipient,
+  withdrawViaMercury,
+  BankAccountInfo,
+} from './actions'
+
+type AccountType = BankAccountInfo['electronicAccountType']
+
+const ACCOUNT_TYPES: { value: AccountType; label: string }[] = [
+  { value: 'personalChecking', label: 'Personal Checking' },
+  { value: 'personalSavings', label: 'Personal Savings' },
+  { value: 'businessChecking', label: 'Business Checking' },
+  { value: 'businessSavings', label: 'Business Savings' },
+]
+
+function Label(props: { htmlFor: string; children: React.ReactNode }) {
+  return (
+    <label
+      htmlFor={props.htmlFor}
+      className="mb-1 block text-sm font-medium text-gray-700"
+    >
+      {props.children}
+    </label>
+  )
+}
+
+function Alert(props: {
+  type: 'error' | 'success'
+  children: React.ReactNode
+}) {
+  const cls =
+    props.type === 'error'
+      ? 'bg-rose-50 text-rose-800'
+      : 'bg-emerald-50 text-emerald-800'
+  return <div className={`rounded-md p-4 text-sm ${cls}`}>{props.children}</div>
+}
+
+// --- Bank info form (shown when no Mercury recipient exists) ---
+
+export function BankInfoForm() {
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [bankInfo, setBankInfo] = useState<BankAccountInfo>({
+    accountNumber: '',
+    routingNumber: '',
+    electronicAccountType: 'personalChecking',
+    address: {
+      address1: '',
+      city: '',
+      region: '',
+      postalCode: '',
+      country: 'US',
+    },
+  })
+
+  const update = (patch: Partial<BankAccountInfo>) =>
+    setBankInfo((prev) => ({ ...prev, ...patch }))
+  const updateAddress = (patch: Partial<BankAccountInfo['address']>) =>
+    setBankInfo((prev) => ({
+      ...prev,
+      address: { ...prev.address, ...patch },
+    }))
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    try {
+      const result = await createMercuryRecipient(bankInfo)
+      if (result.success) {
+        window.location.reload()
+      } else {
+        setError(result.error)
+      }
+    } catch {
+      setError('An unexpected error occurred')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Col className="mx-auto max-w-2xl p-6">
+      <form onSubmit={handleSubmit}>
+        <Card>
+          <Col className="gap-5">
+            <div>
+              <h1 className="text-2xl font-bold">Connect Your Bank Account</h1>
+              <p className="mt-1 text-sm text-gray-600">
+                Enter your US bank account details to enable withdrawals.
+              </p>
+            </div>
+
+            {error && <Alert type="error">{error}</Alert>}
+
+            <div>
+              <Label htmlFor="routingNumber">Routing Number</Label>
+              <Input
+                id="routingNumber"
+                placeholder="9 digits"
+                maxLength={9}
+                value={bankInfo.routingNumber}
+                onChange={(e) =>
+                  update({ routingNumber: e.target.value.replace(/\D/g, '') })
+                }
+                disabled={submitting}
+                required
+                className="w-full"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="accountNumber">Account Number</Label>
+              <Input
+                id="accountNumber"
+                placeholder="Account number"
+                value={bankInfo.accountNumber}
+                onChange={(e) =>
+                  update({ accountNumber: e.target.value.replace(/\D/g, '') })
+                }
+                disabled={submitting}
+                required
+                className="w-full"
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="accountType">Account Type</Label>
+              <select
+                id="accountType"
+                value={bankInfo.electronicAccountType}
+                onChange={(e) =>
+                  update({
+                    electronicAccountType: e.target.value as AccountType,
+                  })
+                }
+                disabled={submitting}
+                className="h-12 w-full rounded-md border border-gray-300 bg-white px-4 shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-500"
+              >
+                {ACCOUNT_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="border-t pt-4">
+              <h3 className="mb-3 text-sm font-semibold text-gray-900">
+                Account Holder Address
+              </h3>
+              <Col className="gap-3">
+                <div>
+                  <Label htmlFor="address1">Street Address</Label>
+                  <Input
+                    id="address1"
+                    placeholder="123 Main St"
+                    value={bankInfo.address.address1}
+                    onChange={(e) => updateAddress({ address1: e.target.value })}
+                    disabled={submitting}
+                    required
+                    className="w-full"
+                  />
+                </div>
+
+                <Row className="gap-3">
+                  <div className="flex-1">
+                    <Label htmlFor="city">City</Label>
+                    <Input
+                      id="city"
+                      placeholder="City"
+                      value={bankInfo.address.city}
+                      onChange={(e) => updateAddress({ city: e.target.value })}
+                      disabled={submitting}
+                      required
+                      className="w-full"
+                    />
+                  </div>
+                  <div className="w-24">
+                    <Label htmlFor="region">State</Label>
+                    <Input
+                      id="region"
+                      placeholder="CA"
+                      maxLength={2}
+                      value={bankInfo.address.region}
+                      onChange={(e) =>
+                        updateAddress({
+                          region: e.target.value.toUpperCase(),
+                        })
+                      }
+                      disabled={submitting}
+                      required
+                      className="w-full"
+                    />
+                  </div>
+                </Row>
+
+                <Row className="gap-3">
+                  <div className="flex-1">
+                    <Label htmlFor="postalCode">ZIP Code</Label>
+                    <Input
+                      id="postalCode"
+                      placeholder="12345"
+                      maxLength={10}
+                      value={bankInfo.address.postalCode}
+                      onChange={(e) =>
+                        updateAddress({ postalCode: e.target.value })
+                      }
+                      disabled={submitting}
+                      required
+                      className="w-full"
+                    />
+                  </div>
+                  <div className="w-24">
+                    <Label htmlFor="country">Country</Label>
+                    <Input
+                      id="country"
+                      placeholder="US"
+                      maxLength={2}
+                      value={bankInfo.address.country}
+                      onChange={(e) =>
+                        updateAddress({
+                          country: e.target.value.toUpperCase(),
+                        })
+                      }
+                      disabled={submitting}
+                      required
+                      className="w-full"
+                    />
+                  </div>
+                </Row>
+              </Col>
+            </div>
+
+            <Button
+              type="submit"
+              size="lg"
+              color="orange"
+              className="w-full"
+              disabled={submitting}
+              loading={submitting}
+            >
+              {submitting ? 'Connecting...' : 'Connect Bank Account'}
+            </Button>
+          </Col>
+        </Card>
+      </form>
+    </Col>
+  )
+}
+
+// --- Recipient info + withdraw form (shown when Mercury recipient exists) ---
+
+export function WithdrawForm(props: {
+  recipientName: string
+  accountLastFour: string | undefined
+  accountType: string | undefined
+  withdrawBalance: number
+}) {
+  const { recipientName, accountLastFour, accountType, withdrawBalance } = props
+  const [amount, setAmount] = useState('')
+  const [withdrawing, setWithdrawing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const accountTypeLabel =
+    ACCOUNT_TYPES.find((t) => t.value === accountType)?.label ?? accountType
+
+  const handleWithdraw = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSuccess(null)
+
+    const dollars = parseFloat(amount)
+    if (isNaN(dollars) || dollars <= 0) {
+      setError('Enter a valid amount')
+      return
+    }
+
+    setWithdrawing(true)
+    try {
+      const result = await withdrawViaMercury(dollars)
+      if (result.success) {
+        setSuccess(`Withdrawal of $${dollars.toFixed(2)} submitted.`)
+        setAmount('')
+      } else {
+        setError(result.error)
+      }
+    } catch {
+      setError('An unexpected error occurred')
+    } finally {
+      setWithdrawing(false)
+    }
+  }
+
+  return (
+    <Col className="mx-auto max-w-2xl gap-6 p-6">
+      {/* Account info card */}
+      <Card>
+        <Col className="gap-4">
+          <h2 className="text-lg font-bold">Bank Account on File</h2>
+          <div className="space-y-2 rounded-lg bg-gray-50 p-4 text-sm">
+            <Row className="justify-between">
+              <span className="text-gray-600">Name</span>
+              <span className="font-medium">{recipientName}</span>
+            </Row>
+            {accountTypeLabel && (
+              <Row className="justify-between">
+                <span className="text-gray-600">Type</span>
+                <span className="font-medium">{accountTypeLabel}</span>
+              </Row>
+            )}
+            {accountLastFour && (
+              <Row className="justify-between">
+                <span className="text-gray-600">Account</span>
+                <span className="font-medium">****{accountLastFour}</span>
+              </Row>
+            )}
+          </div>
+          <p className="text-xs text-gray-500">
+            To update your bank info, contact austin@manifund.org.
+          </p>
+        </Col>
+      </Card>
+
+      {/* Withdraw card */}
+      <Card>
+        <form onSubmit={handleWithdraw}>
+          <Col className="gap-5">
+            <h2 className="text-lg font-bold">Withdraw Funds</h2>
+
+            {success && <Alert type="success">{success}</Alert>}
+            {error && <Alert type="error">{error}</Alert>}
+
+            <div className="rounded-lg bg-gray-50 p-4">
+              <Row className="justify-between">
+                <span className="text-sm text-gray-600">
+                  Available Balance
+                </span>
+                <span className="text-lg font-bold">
+                  ${withdrawBalance.toFixed(2)}
+                </span>
+              </Row>
+            </div>
+
+            <div>
+              <Label htmlFor="amount">Amount (USD)</Label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">
+                  $
+                </span>
+                <Input
+                  id="amount"
+                  type="number"
+                  step="0.01"
+                  min="1"
+                  max={withdrawBalance}
+                  placeholder="0.00"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  disabled={withdrawing}
+                  required
+                  className="w-full pl-8"
+                />
+              </div>
+            </div>
+
+            <Button
+              type="submit"
+              size="lg"
+              color="orange"
+              className="w-full"
+              disabled={withdrawing || !amount}
+              loading={withdrawing}
+            >
+              {withdrawing ? 'Processing...' : 'Withdraw'}
+            </Button>
+          </Col>
+        </form>
+      </Card>
+    </Col>
+  )
+}

--- a/components/comment-rxn.tsx
+++ b/components/comment-rxn.tsx
@@ -351,6 +351,7 @@ export function CommentRxnsPanel(props: {
           bio: '',
           long_description: {},
           regranter_status: false,
+          mercury_recipient_id: null,
           stripe_connect_id: null,
           type: 'individual',
           website: null,

--- a/db/database.types.ts
+++ b/db/database.types.ts
@@ -347,6 +347,7 @@ export type Database = {
           full_name: string
           id: string
           long_description: Json | null
+          mercury_recipient_id: string | null
           regranter_status: boolean
           stripe_connect_id: string | null
           type: Database['public']['Enums']['profile_type']
@@ -360,6 +361,7 @@ export type Database = {
           full_name?: string
           id?: string
           long_description?: Json | null
+          mercury_recipient_id?: string | null
           regranter_status?: boolean
           stripe_connect_id?: string | null
           type?: Database['public']['Enums']['profile_type']
@@ -373,6 +375,7 @@ export type Database = {
           full_name?: string
           id?: string
           long_description?: Json | null
+          mercury_recipient_id?: string | null
           regranter_status?: boolean
           stripe_connect_id?: string | null
           type?: Database['public']['Enums']['profile_type']

--- a/supabase/migrations/20260205000000_add_mercury_recipient_id.sql
+++ b/supabase/migrations/20260205000000_add_mercury_recipient_id.sql
@@ -1,0 +1,6 @@
+-- Add Mercury recipient ID to profiles table
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS mercury_recipient_id TEXT;
+
+-- Add comment explaining the field
+COMMENT ON COLUMN public.profiles.mercury_recipient_id IS 'Mercury API recipient ID for bank payouts';


### PR DESCRIPTION
This PR isn't good to merge as is, but maybe a helpful reference, from like 6months ago last time I tried this.

Basically, one kind of thing we could do to make withdrawals faster esp for intl people: don't make them wait for our "Mercury Recipient via Email" flow, just have them input it proactively. It's a bit cursed because bank detail and address formats vary enormously between countries. Mercury has some kind of API that might theoretically support this, which is what I tried to wrap a UI around. (But, maybe even the complete version doesn't work, and wrapping in this way might be brittle to future changes anyways).

I really wish they supported their "become a mercury recipient via email" flow as an API. (maybe, we should just ask them if they could support that??)

Alternatives include using other payout management services (like 2y ago, we went on a call with dots.dev and they seem okay). Or just continuing to do manual payouts via Airtable + human.