### PR TITLE
Bundle PostHog replay recorder

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,4 +1,6 @@
 import posthog from 'posthog-js'
+// Bundle the replay recorder: fetching it at runtime gets adblocked by filename
+import 'posthog-js/dist/posthog-recorder'
 import { NEXT_PUBLIC_POSTHOG_KEY } from './db/env'
 
 // NODE_ENV gate rather than isProd(): `bun run dev` uses prod Supabase but must not send analytics


### PR DESCRIPTION
Adblockers block the runtime fetch of /flux/static/posthog-recorder.js by filename, so session replay never started for adblocked visitors. Importing posthog-js/dist/posthog-recorder bundles it into our own hashed chunks instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)