### PR TITLE
Point project-activation email at the withdraw page

### DIFF
--- a/utils/activate-project.ts
+++ b/utils/activate-project.ts
@@ -125,15 +125,14 @@ async function activateProject(project: Project, followerIds: string[]) {
     })
   )
   const creatorSubject = `Your project, "${project.title}" is active!`
-  const creatorMessage = `Your project, "${project.title}", has completed the seed funding process and become active! You can now withdraw any funds you've received for this project from your profile page.`
+  const creatorMessage = `Your project, "${project.title}", has completed the seed funding process and become active! You can now withdraw the funds you've received for this project anytime you want.`
   await sendTemplateEmail(
-    TEMPLATE_IDS.VERDICT,
+    TEMPLATE_IDS.GENERIC_NOTIF,
     {
-      recipientFullName: creatorProfile.full_name ?? 'project creator',
-      verdictMessage: creatorMessage,
-      projectUrl: `${getURL()}/projects/${project.slug}`,
+      notifText: creatorMessage,
+      buttonUrl: `${getURL()}/withdraw`,
+      buttonText: 'Withdraw funds',
       subject: creatorSubject,
-      adminName: 'The Manifund team',
     },
     project.creator
   )


### PR DESCRIPTION
Creator's activation email now says funds can be withdrawn anytime and its button links to /withdraw instead of the project page (switched to the generic-notif template since the verdict template's button label is hardcoded to "View project" in Postmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)