### PR TITLE
Add /sso: hand a Manifund session to Trace

### DIFF
--- a/app/sso/route.ts
+++ b/app/sso/route.ts
@@ -3,8 +3,8 @@ import { createServerSupabaseClient } from '@/db/supabase-server'
 
 import type { NextRequest } from 'next/server'
 
-// Hands a Manifund session to a sibling Manifund-run site (currently Trace at
-// trace.manifund.org), so people don't need a second sign-in. Both sites use
+// Hands a Manifund session to Trace at
+// trace.manifund.org, so people don't need a second sign-in. Both sites use
 // this Supabase project, so it is the same account either way — only the
 // session cookie is per-host, and this passes the tokens across.
 //
@@ -15,8 +15,6 @@ import type { NextRequest } from 'next/server'
 //               own cookie and clears them from the address bar.
 // Signed out -> send them through the normal login page and come back here.
 //
-// `next` is checked against an allowlist: an open redirect here would hand
-// someone's session to whatever host they named.
 const ALLOWED_TARGETS = ['https://trace.manifund.org']
 
 export async function GET(request: NextRequest) {

--- a/app/sso/route.ts
+++ b/app/sso/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { createServerSupabaseClient } from '@/db/supabase-server'
+
+import type { NextRequest } from 'next/server'
+
+// Hands a Manifund session to a sibling Manifund-run site (currently Trace at
+// trace.manifund.org), so people don't need a second sign-in. Both sites use
+// this Supabase project, so it is the same account either way — only the
+// session cookie is per-host, and this passes the tokens across.
+//
+//   /sso?next=https://trace.manifund.org/auth/handoff&then=/suggestions
+//
+// Signed in  -> redirect to `next` with the tokens in the URL fragment, which
+//               browsers never send to a server; the target swaps them for its
+//               own cookie and clears them from the address bar.
+// Signed out -> send them through the normal login page and come back here.
+//
+// `next` is checked against an allowlist: an open redirect here would hand
+// someone's session to whatever host they named.
+const ALLOWED_TARGETS = ['https://trace.manifund.org']
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url)
+  const next = url.searchParams.get('next') ?? ''
+  const then = url.searchParams.get('then') ?? '/'
+
+  const target = ALLOWED_TARGETS.find(
+    (allowed) => next === allowed || next.startsWith(`${allowed}/`)
+  )
+  if (!target) {
+    return NextResponse.json({ error: 'next must be an allowed Manifund site' }, { status: 400 })
+  }
+
+  const supabase = await createServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    // Log in, then come back here to complete the handoff.
+    const login = new URL('/login', url.origin)
+    login.searchParams.set('next', `/sso?next=${encodeURIComponent(next)}&then=${encodeURIComponent(then)}`)
+    return NextResponse.redirect(login)
+  }
+
+  const handoff = new URL(next)
+  handoff.hash = new URLSearchParams({
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+    next: then.startsWith('/') ? then : '/',
+  }).toString()
+  return NextResponse.redirect(handoff)
+}


### PR DESCRIPTION
This adds `/sso`, which hands a Manifund session across to Trace:

- **Signed in** → redirect to the target with `access_token` / `refresh_token` in the URL **fragment**. Fragments are never sent to a server; Trace's `/auth/handoff` swaps them for its own cookie and immediately clears them from the address bar with `history.replaceState`.
- **Signed out** → through the normal `/login` page, returning here afterwards.

### Safety

- **Redirect allowlist.** `next` must be `https://trace.manifund.org`. An open redirect here would hand a user's session to any host in the query string.
- **Rollback** is deleting the route; nothing depends on it inside Manifund.

Trace's half is already deployed ([manifund/trace#d2c7c6c](https://github.com/manifund/trace/commit/d2c7c6c)) and its button currently points at this route, so this PR will enable Trace sign-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
