### PR TITLE
Update wire/DAF deposit timing copy

### DIFF
--- a/components/deposit-buttons.tsx
+++ b/components/deposit-buttons.tsx
@@ -95,7 +95,8 @@ function WireTab() {
           </SiteLink>
         </li>
         <li>
-          We&apos;ll update your Manifund balance upon receiving your donation (typically 5-10 days)
+          We&apos;ll update your Manifund balance upon receiving your donation (typically 1-5 days
+          for wire/ACH/crypto, and longer for DAFs)
         </li>
       </ol>
     </div>


### PR DESCRIPTION
Changes the deposit modal's wire/crypto/DAF tab to say balances update in typically 1-5 days for wire/ACH/crypto, and longer for DAFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)