### PR TITLE
Send people where they were going after they sign in

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { createServerSupabaseClient } from '@/db/supabase-server'
+import { safeNext } from '@/utils/safe-next'
 import { NextResponse } from 'next/server'
 
 import type { NextRequest } from 'next/server'
@@ -7,7 +8,9 @@ import type { NextRequest } from 'next/server'
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
-  const next = requestUrl.searchParams.get('next') || '/'
+  // new URL(next, origin) would follow an absolute URL straight off the site,
+  // and this value now comes from a query string the user can set.
+  const next = safeNext(requestUrl.searchParams.get('next'))
 
   if (code) {
     const supabase = await createServerSupabaseClient()

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@
 import { use } from 'react'
 
 import AuthModal from '@/components/auth/AuthModal'
+import { safeNext } from '@/utils/safe-next'
 
 export default function LoginPage(props: {
   searchParams: Promise<{
@@ -9,6 +10,7 @@ export default function LoginPage(props: {
     error_code?: string
     error_description?: string
     email?: string
+    next?: string
   }>
 }) {
   const searchParams = use(props.searchParams)
@@ -21,10 +23,17 @@ export default function LoginPage(props: {
     : undefined
 
   const recommendedEmail = searchParams.email || undefined
+  // /sso sends people here to sign in and then resume the handoff to Trace.
+  const next = safeNext(searchParams.next)
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <AuthModal isOpen={true} authError={authError} recommendedEmail={recommendedEmail} />
+      <AuthModal
+        isOpen={true}
+        authError={authError}
+        recommendedEmail={recommendedEmail}
+        next={next}
+      />
     </div>
   )
 }

--- a/components/auth/AuthModal.tsx
+++ b/components/auth/AuthModal.tsx
@@ -15,6 +15,9 @@ interface AuthModalProps {
   onClose?: () => void
   authError?: AuthError
   recommendedEmail?: string
+  // Where to go once signed in. Defaults to the home page; /login passes the
+  // path that sent you here, so the /sso handoff to Trace can resume.
+  next?: string
 }
 
 type AuthMode = 'signin' | 'signup' | 'forgot-password'
@@ -39,6 +42,7 @@ export default function AuthModal({
   onClose,
   authError,
   recommendedEmail,
+  next = '/',
 }: AuthModalProps) {
   const [mode, setMode] = useState<AuthMode>('signin')
   const [isPending, startTransition] = useTransition()
@@ -64,7 +68,7 @@ export default function AuthModal({
           if (result?.type === 'success') {
             markUserAsReturning()
             onClose?.()
-            window.location.href = '/'
+            window.location.href = next
             return
           }
         } else if (mode === 'signup') {
@@ -90,7 +94,7 @@ export default function AuthModal({
     startTransition(async () => {
       // Mark as returning user before the redirect happens
       markUserAsReturning()
-      const result = await signInWithGoogle()
+      const result = await signInWithGoogle(next)
       if (result?.type === 'success') {
         markUserAsReturning()
         window.location.href = result.text

--- a/lib/auth-actions.ts
+++ b/lib/auth-actions.ts
@@ -8,6 +8,7 @@ import {
   DISABLE_NEW_SIGNUPS_AND_PROJECTS,
   SIGNUP_DISABLED_MESSAGE,
 } from '@/utils/constants'
+import { safeNext } from '@/utils/safe-next'
 
 export type AuthResult = {
   type: 'error' | 'success'
@@ -83,11 +84,17 @@ export async function resetPassword(formData: FormData): Promise<AuthResult> {
   }
 }
 
-export async function signInWithGoogle(): Promise<AuthResult> {
+export async function signInWithGoogle(next?: string): Promise<AuthResult> {
   const supabase = await createServerSupabaseClient()
 
+  // Google sends the user to /auth/callback, which reads `next` — without it
+  // every OAuth sign-in lands on the home page regardless of where it started.
+  const destination = safeNext(next)
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
+    options: {
+      redirectTo: `${getURL()}auth/callback?next=${encodeURIComponent(destination)}`,
+    },
   })
 
   if (error) {

--- a/utils/safe-next.ts
+++ b/utils/safe-next.ts
@@ -1,0 +1,13 @@
+// Where to send someone after they sign in.
+//
+// The value arrives in a query string, so it is attacker-controlled: a link to
+// manifund.org/login?next=https://evil.example would otherwise send a
+// freshly-authenticated user straight off the site. Only same-site paths are
+// allowed through, and anything else falls back to the home page.
+export function safeNext(next: string | null | undefined, fallback = '/'): string {
+  if (!next) return fallback
+  // Must be a path on this site: one leading slash, and not "//host" or
+  // "/\host", both of which browsers read as protocol-relative URLs.
+  if (!next.startsWith('/') || next.startsWith('//') || next.startsWith('/\\')) return fallback
+  return next
+}


### PR DESCRIPTION
Fixes the sign-in loop between Trace and Manifund.

## The bug

`/sso` hands a Manifund session to Trace. When nobody is signed in it redirects to `/login?next=/sso?...` so the handoff can resume after login — but `app/login/page.tsx` never read `next`, and `AuthModal` hardcoded `window.location.href = '/'`. So you signed in, landed on Manifund's front page, and the handoff was lost.

From Trace it looked like the sign-in button took you to Manifund and left you there. You then had to go back to Trace and sign in a second time, which worked because by then Manifund had a session.

## The fix

- `/login` reads `next` and passes it to `AuthModal`
- `AuthModal` uses it for email/password, and passes it to `signInWithGoogle` for OAuth
- `signInWithGoogle` sets `redirectTo: .../auth/callback?next=...`; the callback already honoured `next`

Every other caller of `AuthModal` (`/edit-profile`, `/withdraw`, `/evals-form`) omits the prop and still goes to the home page.

## Security

`next` arrives in a query string, so it is attacker-controlled. `safeNext` allows only same-site paths — it rejects absolute URLs and the protocol-relative `//host` form, both of which would otherwise send a freshly-authenticated user off the site.

`/auth/callback` validates too. It builds `new URL(next, origin)`, which follows an absolute URL as-is; that was unreachable before, and becomes reachable now that OAuth carries the value through.

## Checks

- `bun run build` passes
- The `redirectTo` query string is already covered by the project's `https://manifund.org/**` allow-list entry, and `signUp` has been using the same `auth/callback?next=` pattern in production

## Testing after merge

Sign out of Manifund entirely, then click "Sign in with Manifund" on trace.manifund.org — it should return to Trace signed in, rather than stopping at manifund.org. Worth trying both the email and Google paths.