### PR TITLE
Point user-facing contact prompts at hi@manifund.org

### DIFF
--- a/app/about/donor-faq/page.tsx
+++ b/app/about/donor-faq/page.tsx
@@ -150,8 +150,8 @@ export default function DonorFaqPage() {
         </p>
         <h2>More questions? Contact us!</h2>
         <p>
-          Reach out to <a href="mailto:austin@manifund.org">austin@manifund.org</a> with any
-          questions you have~
+          Reach out to <a href="mailto:hi@manifund.org">hi@manifund.org</a> with any questions you
+          have~
         </p>
       </div>
     </div>

--- a/app/about/regranting/page.tsx
+++ b/app/about/regranting/page.tsx
@@ -6,7 +6,7 @@ import { ExampleRegrants } from './example-regrants'
 const DonationCTA = () => (
   <div className="my-8 text-center">
     <a
-      href="mailto:austin@manifund.org"
+      href="mailto:hi@manifund.org"
       className="inline-block rounded-lg bg-orange-600 px-6 py-3 text-white hover:bg-orange-700"
     >
       Donate to AI Safety Regranting
@@ -158,7 +158,7 @@ export default async function RegrantingPage() {
           nominate specific regrantors who share your values and interests. We do ask large donors
           to cover a 5% fiscal sponsorship fee, which offsets our operational costs & salaries.
         </p>
-        <p>Get in touch with Austin (austin@manifund.org) if you&apos;re interested in donating!</p>
+        <p>Get in touch (hi@manifund.org) if you&apos;re interested in donating!</p>
       </div>
       <DonationCTA />
     </div>

--- a/app/edit-profile/roles/claim-roles.tsx
+++ b/app/edit-profile/roles/claim-roles.tsx
@@ -125,8 +125,7 @@ export function ClaimRoles(props: {
             the waitlist
           </Link>{' '}
           to be notified if & when we receive more funding, or email{' '}
-          <a href="mailto:austin@manifund.org">austin@manifund.org</a> if you know someone might
-          contribute!
+          <a href="mailto:hi@manifund.org">hi@manifund.org</a> if you know someone might contribute!
         </AlertBox>
         <br />
         <br />

--- a/app/no-access.tsx
+++ b/app/no-access.tsx
@@ -21,11 +21,8 @@ export default function NoAccess() {
       </div>
       <p className="text-center text-sm leading-7 text-gray-600">
         If you weren’t expecting this, you can email{' '}
-        <a
-          className="font-semibold text-orange-600 hover:underline"
-          href="mailto:austin@manifund.org"
-        >
-          austin@manifund.org
+        <a className="font-semibold text-orange-600 hover:underline" href="mailto:hi@manifund.org">
+          hi@manifund.org
         </a>{' '}
         or send us a message on{' '}
         <a

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -20,11 +20,8 @@ export default function NotFound() {
       </div>
       <p className="text-center text-sm leading-7 text-gray-600">
         If you weren’t expecting this, you can email{' '}
-        <a
-          className="font-semibold text-orange-600 hover:underline"
-          href="mailto:austin@manifund.org"
-        >
-          austin@manifund.org
+        <a className="font-semibold text-orange-600 hover:underline" href="mailto:hi@manifund.org">
+          hi@manifund.org
         </a>{' '}
         or send us a message on{' '}
         <a

--- a/app/projects/[slug]/creator-action-panel.tsx
+++ b/app/projects/[slug]/creator-action-panel.tsx
@@ -167,7 +167,7 @@ function CloseProject(props: { projectId: string }) {
           <p className="mt-2 text-sm text-gray-600">
             <strong>Your report will be posted as a public comment.</strong> If there&apos;s
             anything you&apos;d like to share with Manifund but cannot post publicly, you can email
-            austin@manifund.org.
+            hi@manifund.org.
           </p>
         </div>
         <TextEditor editor={editor} />

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -3,7 +3,7 @@ export const CENTS_PER_DOLLAR = 100
 // Temporary flag to disable new signups and projects during spambot attack
 export const DISABLE_NEW_SIGNUPS_AND_PROJECTS = false
 export const SIGNUP_DISABLED_MESSAGE =
-  'New projects and accounts disabled as we deal with spambots; contact austin@manifund.org if you have questions.'
+  'New projects and accounts disabled as we deal with spambots; contact hi@manifund.org if you have questions.'
 
 // Spam filter (runs before Pangram on project create/edit/publish).
 // SPAM_FILTER_ENABLED: master switch. When false, the gate is skipped entirely.


### PR DESCRIPTION
Swaps `austin@manifund.org` for `hi@manifund.org` in the 8 places where the UI tells a user to email us. Internal recipient lists (weekly digest, close-grants reminder, idle-balance summary) still go to Austin and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)