### PR TITLE
Gate approval alerts on signed agreements, add per-project pause button

### DIFF
--- a/app/admin/approvals/page.tsx
+++ b/app/admin/approvals/page.tsx
@@ -1,5 +1,6 @@
 import { createAdminClient } from '@/db/edge'
 import { GrantVerdict } from '../grant-verdict'
+import { PauseAlertsButton } from '../pause-alerts-button'
 import Link from 'next/link'
 import clsx from 'clsx'
 import { Table } from '@/components/table-catalyst'
@@ -12,7 +13,7 @@ export default async function ApprovalsPage() {
   const { data: projects } = await supabaseAdmin
     .from('projects')
     .select(
-      'id, title, slug, stage, approved, min_funding, lobbying, signed_agreement, profiles!projects_creator_fkey(username, full_name), bids(amount, type)'
+      'id, title, slug, stage, approved, min_funding, lobbying, signed_agreement, alerts_paused, profiles!projects_creator_fkey(username, full_name), bids(amount, type)'
     )
     .eq('stage', 'proposal')
     .order('created_at', { ascending: false })
@@ -36,12 +37,13 @@ export default async function ApprovalsPage() {
         <tr>
           <th className="p-2 text-center">Creator</th>
           <th className="p-2 text-center">Project</th>
+          <th className="p-2 text-center">Alerts</th>
           <th className="p-2 text-center">Grant verdict</th>
         </tr>
       </thead>
       <tbody className="p-2">
         {projectsToApprove.map((project) => (
-          <tr key={project.id}>
+          <tr key={project.id} className={clsx(project.alerts_paused && 'opacity-60')}>
             <td>
               <Link href={`/${project.profiles?.username}`}>{project.profiles?.full_name}</Link>
             </td>
@@ -52,6 +54,9 @@ export default async function ApprovalsPage() {
               >
                 {project.title}
               </Link>
+            </td>
+            <td>
+              <PauseAlertsButton projectId={project.id} alertsPaused={project.alerts_paused} />
             </td>
             <td>
               <GrantVerdict projectId={project.id} lobbying={project.lobbying} />

--- a/app/admin/pause-alerts-button.tsx
+++ b/app/admin/pause-alerts-button.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Button } from '@/components/button'
+import { BellAlertIcon, BellSlashIcon } from '@heroicons/react/24/outline'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { toast } from 'react-hot-toast'
+
+export function PauseAlertsButton(props: { projectId: string; alertsPaused: boolean }) {
+  const { projectId, alertsPaused } = props
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const router = useRouter()
+  return (
+    <Button
+      size="2xs"
+      color={alertsPaused ? 'gray' : 'light-orange'}
+      loading={isSubmitting}
+      className="flex items-center gap-1"
+      onClick={async () => {
+        setIsSubmitting(true)
+        const response = await fetch('/api/set-alerts-paused', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ projectId, alertsPaused: !alertsPaused }),
+        })
+        setIsSubmitting(false)
+        if (!response.ok) {
+          const body = await response.json().catch(() => null)
+          toast.error(body?.error ?? 'Failed to update project alerts.')
+          return
+        }
+        router.refresh()
+      }}
+    >
+      {alertsPaused ? (
+        <>
+          <BellSlashIcon className="h-4 w-4" /> Paused
+        </>
+      ) : (
+        <>
+          <BellAlertIcon className="h-4 w-4" /> Pause
+        </>
+      )}
+    </Button>
+  )
+}

--- a/db/database.types.ts
+++ b/db/database.types.ts
@@ -791,6 +791,7 @@ export type Database = {
       projects: {
         Row: {
           ai_fraction: number | null
+          alerts_paused: boolean
           amm_shares: number | null
           approved: boolean | null
           auction_close: string | null
@@ -817,6 +818,7 @@ export type Database = {
         }
         Insert: {
           ai_fraction?: number | null
+          alerts_paused?: boolean
           amm_shares?: number | null
           approved?: boolean | null
           auction_close?: string | null
@@ -843,6 +845,7 @@ export type Database = {
         }
         Update: {
           ai_fraction?: number | null
+          alerts_paused?: boolean
           amm_shares?: number | null
           approved?: boolean | null
           auction_close?: string | null

--- a/pages/api/close-grants.ts
+++ b/pages/api/close-grants.ts
@@ -71,30 +71,33 @@ async function closeProject(
   const minIncludingAmm = getMinIncludingAmm(project)
   const activeAuction = !!prizeCause?.cert_params?.auction && project.stage === 'proposal'
   if (amountRaised >= minIncludingAmm) {
-    if (!project.signed_agreement) {
-      await sendTemplateEmail(
-        TEMPLATE_IDS.GENERIC_NOTIF,
-        {
-          notifText: `Your project "${project.title}" has enough funding to proceed but is awaiting your signature on the grant agreement. Please sign the agreement to activate your grant.`,
-          buttonUrl: `https://manifund.org/projects/${project.slug}/agreement`,
-          buttonText: 'Sign agreement',
-          subject: 'Manifund: Reminder to sign your grant agreement',
-        },
-        project.creator
-      )
-    }
-    if (!project.approved) {
-      await sendTemplateEmail(
-        TEMPLATE_IDS.GENERIC_NOTIF,
-        {
-          notifText: `The project "${project.title}" has enough funding but is awaiting admin approval.`,
-          buttonUrl: `https://manifund.org/projects/${project.slug}`,
-          buttonText: 'See project',
-          subject: 'Manifund: Reminder to approve project',
-        },
-        undefined,
-        'austin@manifund.org'
-      )
+    if (!project.alerts_paused) {
+      if (!project.signed_agreement) {
+        await sendTemplateEmail(
+          TEMPLATE_IDS.GENERIC_NOTIF,
+          {
+            notifText: `Your project "${project.title}" has enough funding to proceed but is awaiting your signature on the grant agreement. Please sign the agreement to activate your grant.`,
+            buttonUrl: `https://manifund.org/projects/${project.slug}/agreement`,
+            buttonText: 'Sign agreement',
+            subject: 'Manifund: Reminder to sign your grant agreement',
+          },
+          project.creator
+        )
+      }
+      // Nothing for an admin to act on until the creator has signed.
+      if (!project.approved && project.signed_agreement) {
+        await sendTemplateEmail(
+          TEMPLATE_IDS.GENERIC_NOTIF,
+          {
+            notifText: `The project "${project.title}" has enough funding but is awaiting admin approval.`,
+            buttonUrl: `https://manifund.org/projects/${project.slug}`,
+            buttonText: 'See project',
+            subject: 'Manifund: Reminder to approve project',
+          },
+          undefined,
+          'austin@manifund.org'
+        )
+      }
     }
     if (project.approved && project.signed_agreement && activeAuction) {
       await resolveAuction(project)

--- a/pages/api/set-alerts-paused.ts
+++ b/pages/api/set-alerts-paused.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createAdminClient, getUserAndClient } from '@/db/edge'
+import { isAdmin } from '@/db/profile'
+
+export const config = {
+  runtime: 'edge',
+  regions: ['sfo1'],
+}
+
+type SetAlertsPausedProps = {
+  projectId: string
+  alertsPaused: boolean
+}
+
+export default async function handler(req: NextRequest) {
+  const { projectId, alertsPaused } = (await req.json()) as SetAlertsPausedProps
+  const { user } = await getUserAndClient(req)
+  if (!user || !isAdmin(user)) {
+    return NextResponse.json({ error: 'Only admins can pause project alerts.' }, { status: 403 })
+  }
+
+  const supabaseAdmin = createAdminClient()
+  const { error } = await supabaseAdmin
+    .from('projects')
+    .update({ alerts_paused: alertsPaused })
+    .eq('id', projectId)
+  if (error) {
+    console.error(error)
+    return NextResponse.json(
+      { error: `Failed to update project alerts: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  return NextResponse.json('success')
+}

--- a/supabase/migrations/20260901000000_add_projects_alerts_paused.sql
+++ b/supabase/migrations/20260901000000_add_projects_alerts_paused.sql
@@ -1,0 +1,6 @@
+-- close-grants re-sends its weekly reminders forever while a project sits in
+-- 'proposal' past its close date. Give admins a per-project off switch so
+-- long-stalled proposals stop generating mail without being rejected.
+
+ALTER TABLE "public"."projects"
+  ADD COLUMN IF NOT EXISTS "alerts_paused" boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
The weekly `close-grants` reminder to approve a project now only fires once the creator has signed their grant agreement, and admins get a pause button on `/admin/approvals` to silence reminders on stalled proposals (paused rows show dimmed with a 🔕 Paused button).

Adds `projects.alerts_paused`; the migration has already been applied to prod and `database.types.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)