### PR TITLE
Refresh user balances after $150k Mox withdrawal

### DIFF
--- a/app/finances/users-grid.tsx
+++ b/app/finances/users-grid.tsx
@@ -82,7 +82,7 @@ export function BalanceSheet() {
     mercury: 3_483_610,
     coinbase: 2_073_904,
     // Current users
-    users: -5_689_856,
+    users: -5_543_184,
     // Regranting pot owed + amount assigned to regrantors
     regranting: -2_250_000 + 2_075_000,
     // not credited: -pending grants on Airtable


### PR DESCRIPTION
Mox withdrew $150k from its Manifund platform balance (166,690 → 16,690). Since Mox is us, no wire leaves Mercury, so this is a straight liability reduction with no offsetting cash movement.

User balances: -5,689,856 → -5,543,184. Total net assets: $271,388 → $418,060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)