### PR TITLE
Change manual withdrawal timeline from 10 to 5 business days

### DIFF
--- a/components/withdrawal-details.tsx
+++ b/components/withdrawal-details.tsx
@@ -65,7 +65,7 @@ export function WithdrawalDetails(props: {
             <FeatureCard
               icon={<div className="mx-1 text-xl">🌍</div>}
               title="Large or international"
-              description="Fill out our manual withdraw form with your bank account details and we will manually send you money within 10 business days."
+              description="Fill out our manual withdraw form with your bank account details and we will manually send you money within 5 business days."
               url="https://airtable.com/shrI3XFPivduhbnGa"
               linkText={'Go to form'}
             />


### PR DESCRIPTION
Updates the manual withdrawal copy on the withdraw page to say funds are sent within 5 business days instead of 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rxHEWF5rCw7Gvk9cmoBGg