### PR TITLE
Fix hydration mismatch from relative timestamps

### DIFF
--- a/app/[usernameSlug]/profile-content.tsx
+++ b/app/[usernameSlug]/profile-content.tsx
@@ -19,7 +19,7 @@ import { Row } from '@/components/layout/row'
 import { useState } from 'react'
 import clsx from 'clsx'
 import { RightCarrotIcon } from '@/components/icons'
-import { formatDistanceToNow } from 'date-fns'
+import { RelativeTime } from '@/components/relative-time'
 import { sortBy } from 'es-toolkit'
 import { Col } from '@/components/layout/col'
 import {
@@ -145,7 +145,7 @@ function UserTxns(props: { txns: FullTxn[]; profile: Profile }) {
       <TableRow className="text-sm font-light">
         <TableCell className="max-w-24 truncate">{descriptor}</TableCell>
         <TableCell className="max-w-6 truncate">
-          {formatDistanceToNow(new Date(txn.created_at))} ago
+          <RelativeTime date={txn.created_at} />
         </TableCell>
         <TableCell className="max-w-6 truncate">{txn.type}</TableCell>
         <TableCell className={clsx('w-4 text-right font-bold', sign ? 'text-green-600' : '')}>

--- a/app/[usernameSlug]/profile-donations.tsx
+++ b/app/[usernameSlug]/profile-donations.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from '@/components/tooltip'
 import { BidAndProject } from '@/db/bid'
 import { FullTxn } from '@/db/txn'
 import { HeartIcon, UserIcon, WrenchIcon, UserGroupIcon } from '@heroicons/react/24/solid'
-import { formatDistanceToNow } from 'date-fns'
+import { RelativeTime } from '@/components/relative-time'
 import { orderBy } from 'es-toolkit'
 import Link from 'next/link'
 
@@ -39,9 +39,7 @@ export function OutgoingDonationsHistory(props: {
         name={name}
         url={url}
         amount={donation.amount}
-        date={formatDistanceToNow(new Date(donation.created_at), {
-          addSuffix: true,
-        })}
+        date={<RelativeTime date={donation.created_at} />}
       />
     )
   })
@@ -74,7 +72,7 @@ function DonationRow(props: {
   name: string
   url: string
   amount: number
-  date?: string
+  date?: React.ReactNode
 }) {
   const { type, name, url, amount, date } = props
   return (

--- a/app/projects/[slug]/bids.tsx
+++ b/app/projects/[slug]/bids.tsx
@@ -16,7 +16,7 @@ import { useSupabase } from '@/db/supabase-provider'
 import { Modal } from '@/components/modal'
 import { Profile } from '@/db/profile'
 import { Avatar } from '@/components/avatar'
-import { formatDistanceToNow } from 'date-fns'
+import { RelativeTime } from '@/components/relative-time'
 
 export function Bids(props: {
   bids: BidAndProfile[]
@@ -112,11 +112,10 @@ export function Bid(props: {
         )}
       </Row>
       <Row className="items-center justify-end gap-2">
-        <span className="hidden text-right text-gray-500 sm:block">
-          {formatDistanceToNow(new Date(bid.created_at), {
-            addSuffix: true,
-          })}
-        </span>
+        <RelativeTime
+          date={bid.created_at}
+          className="hidden text-right text-gray-500 sm:block"
+        />
         {userProfile && bid.bidder === userProfile.id && <DeleteBid bidId={bid.id} />}
         {showTrade && project && (
           <Trade

--- a/app/projects/[slug]/shareholders.tsx
+++ b/app/projects/[slug]/shareholders.tsx
@@ -6,9 +6,9 @@ import { TOTAL_SHARES } from '@/db/project'
 import { formatMoneyPrecise, formatPercent, showPrecision } from '@/utils/formatting'
 import clsx from 'clsx'
 import { orderBy } from 'es-toolkit'
-import { formatDistanceToNow } from 'date-fns'
 import { bundleTxns } from '@/utils/math'
 import { Shareholder } from './project-tabs'
+import { RelativeTime } from '@/components/relative-time'
 import { TxnAndProfiles } from '@/db/txn'
 import { calculateAMMPorfolio } from '@/utils/amm'
 import { DividerWithHeader } from '@/components/divider-with-header'
@@ -74,11 +74,10 @@ function Trade(props: {
           <span className="text-gray-500">for</span>
           {formatMoneyPrecise(amountUSD)}
         </Row>
-        <span className="hidden text-right text-gray-500 sm:block">
-          {formatDistanceToNow(new Date(createdAt), {
-            addSuffix: true,
-          })}
-        </span>
+        <RelativeTime
+          date={createdAt}
+          className="hidden text-right text-gray-500 sm:block"
+        />
       </div>
     </Row>
   )

--- a/app/projects/feed-tabs.tsx
+++ b/app/projects/feed-tabs.tsx
@@ -16,7 +16,7 @@ import { Card } from '@/components/layout/card'
 import { FullBid } from '@/db/bid'
 import { Row } from '@/components/layout/row'
 import { UserAvatarAndBadge } from '@/components/user-link'
-import { formatDistanceToNow } from 'date-fns'
+import { RelativeTime } from '@/components/relative-time'
 
 export function FeedTabs(props: {
   recentComments: FullComment[]
@@ -138,11 +138,10 @@ function DonationItem(props: { type: 'donation' | 'bid'; item: FullTxn | FullBid
         </div>
       </Row>
       <Row className="items-center justify-end gap-2">
-        <span className="hidden text-right text-gray-500 sm:block">
-          {formatDistanceToNow(new Date(item.created_at), {
-            addSuffix: true,
-          })}
-        </span>
+        <RelativeTime
+          date={item.created_at}
+          className="hidden text-right text-gray-500 sm:block"
+        />
       </Row>
     </div>
   )

--- a/components/comment.tsx
+++ b/components/comment.tsx
@@ -1,5 +1,5 @@
 import { UserLink } from '@/components/user-link'
-import { formatDistanceToNow } from 'date-fns'
+import { RelativeTime } from '@/components/relative-time'
 import { RichContent } from '@/components/editor'
 import { Row } from '@/components/layout/row'
 import { Col } from '@/components/layout/col'
@@ -96,14 +96,10 @@ export function Comment(props: {
                 creatorBadge={writtenByCreator}
                 className="text-sm font-semibold"
               />
-              <p
+              <RelativeTime
+                date={comment.created_at}
                 className="min-w-fit text-xs text-gray-500"
-                title={new Date(comment.created_at).toLocaleString()}
-              >
-                {formatDistanceToNow(new Date(comment.created_at), {
-                  addSuffix: true,
-                })}
-              </p>
+              />
               <Tooltip text="Copy link to comment" className="cursor-pointer">
                 <LinkIcon
                   className="h-3 w-3 stroke-2 text-gray-500 hover:text-gray-700"

--- a/components/relative-time.tsx
+++ b/components/relative-time.tsx
@@ -1,0 +1,18 @@
+import { formatDistanceToNow } from 'date-fns'
+
+// Relative timestamps drift between server render and client hydration
+// ("3 minutes ago" vs "4 minutes ago"), which fails hydration (React #418)
+// and forces a full client re-render. suppressHydrationWarning keeps the
+// server text instead.
+export function RelativeTime(props: { date: string | Date; className?: string }) {
+  const { date, className } = props
+  return (
+    <span
+      suppressHydrationWarning
+      className={className}
+      title={new Date(date).toLocaleString()}
+    >
+      {formatDistanceToNow(new Date(date), { addSuffix: true })}
+    </span>
+  )
+}


### PR DESCRIPTION
"3 minutes ago" rendered on the server differs by hydration time, failing hydration (React #418, ~75% of our PostHog $exception volume) and forcing a full client re-render. New RelativeTime component renders the timestamp in a suppressHydrationWarning span, used at all six call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rxHEWF5rCw7Gvk9cmoBGg