### PR TITLE
Tighten authorization, validation, and RLS from security audit

### DIFF
--- a/components/oauth-code-handler.tsx
+++ b/components/oauth-code-handler.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useSupabase } from '@/db/supabase-provider'
 import { revalidateAfterAuth } from '@/lib/auth-actions'
+import { safeNext } from '@/utils/safe-next'
 
 // Used to clean up the URL after the OAuth callback is complete.
 export function OAuthCodeHandler() {
@@ -33,7 +34,7 @@ export function OAuthCodeHandler() {
             currentUrl.searchParams.delete('error_description')
 
             // Check if there's a 'next' parameter for redirect
-            const next = searchParams?.get('next') || '/'
+            const next = safeNext(searchParams?.get('next')) || '/'
 
             // Use replaceState to update URL without navigation
             window.history.replaceState({}, '', currentUrl.pathname + currentUrl.search)

--- a/components/tiptap-utils.ts
+++ b/components/tiptap-utils.ts
@@ -31,10 +31,23 @@ type ProsemirrorDOM =
   | string
   | [tag: string, attrs: Record<string, string | number | undefined>, ...content: ProsemirrorDOM[]]
 
+// attrs come from stored user documents, so anything React treats specially
+// (dangerouslySetInnerHTML, event handlers, style objects) must not pass through.
+const sanitizeAttrs = (attrs: Record<string, unknown>) => {
+  const safe: Record<string, string | number | boolean> = {}
+  for (const [key, value] of Object.entries(attrs)) {
+    if (/^on/i.test(key) || key === 'dangerouslySetInnerHTML' || key === 'style') continue
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean')
+      continue
+    safe[key] = value
+  }
+  return safe
+}
+
 const pmdToJSX = (dom: ProsemirrorDOM, children: ReactNode): ReactNode => {
   if (Array.isArray(dom)) {
     const [tag, attrs, ...content] = dom
-    const { class: className, ...rest } = attrs
+    const { class: className, ...rest } = sanitizeAttrs(attrs)
 
     return React.createElement(
       tag,

--- a/db/project.ts
+++ b/db/project.ts
@@ -49,7 +49,7 @@ export async function getProjectById(supabase: SupabaseClient, id: string) {
 export async function getProjectsByUser(supabase: SupabaseClient, user: string) {
   const { data, error } = await supabase
     .from('projects')
-    .select('*, bids(*), txns(*), comments(*), rounds(*), project_transfers(*)')
+    .select('*, bids(*), txns(*), comments(*), rounds(*), project_transfers(id, project_id, recipient_name, transferred, created_at)')
     .eq('creator', user)
   if (error) {
     throw error
@@ -110,7 +110,7 @@ export async function listProjects(supabase: SupabaseClient, limitToProjectIds?:
 
       supabase.from('project_votes').select('project_id, magnitude').in('project_id', batchIds),
 
-      supabase.from('project_transfers').select('*').in('project_id', batchIds),
+      supabase.from('project_transfers').select('id, project_id, recipient_name, transferred, created_at').in('project_id', batchIds),
 
       supabase.from('comments').select('project, id').in('project', batchIds),
     ])
@@ -204,7 +204,7 @@ export async function getFullProjectBySlug(supabase: SupabaseClient, slug: strin
   const { data } = await supabase
     .from('projects')
     .select(
-      '*, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(*), project_transfers(*), project_votes(*), project_follows(follower_id), causes(title, slug)'
+      '*, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(*), project_transfers(id, project_id, recipient_name, transferred, created_at), project_votes(*), project_follows(follower_id), causes(title, slug)'
     )
     .eq('slug', slug)
     .throwOnError()
@@ -243,7 +243,7 @@ export async function getFullProjectsByRound(supabase: SupabaseClient, roundTitl
   const { data, error } = await supabase
     .from('projects')
     .select(
-      'title, id, created_at, creator, slug, blurb, stage, funding_goal, min_funding, type, ai_fraction, quality_score, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(title, slug), project_transfers(*), project_votes(magnitude), causes(title, slug)'
+      'title, id, created_at, creator, slug, blurb, stage, funding_goal, min_funding, type, ai_fraction, quality_score, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(title, slug), project_transfers(id, project_id, recipient_name, transferred, created_at), project_votes(magnitude), causes(title, slug)'
     )
     .neq('stage', 'hidden')
     .neq('stage', 'draft')
@@ -259,7 +259,7 @@ export async function getFullProjectsByCause(supabase: SupabaseClient, causeSlug
   const { data, error } = await supabase
     .from('projects')
     .select(
-      'title, id, created_at, creator, slug, blurb, stage, funding_goal, min_funding, type, amm_shares, founder_shares, auction_close, ai_fraction, quality_score, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(title, slug), project_transfers(*), project_votes(magnitude), project_causes!inner(cause_slug), causes(title, slug)'
+      'title, id, created_at, creator, slug, blurb, stage, funding_goal, min_funding, type, amm_shares, founder_shares, auction_close, ai_fraction, quality_score, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(title, slug), project_transfers(id, project_id, recipient_name, transferred, created_at), project_votes(magnitude), project_causes!inner(cause_slug), causes(title, slug)'
     )
     .eq('project_causes.cause_slug', causeSlug)
     .neq('stage', 'hidden')
@@ -273,7 +273,7 @@ export async function getFullProjectsByCause(supabase: SupabaseClient, causeSlug
 export async function getProjectsPendingTransferByUser(supabase: SupabaseClient, userId: string) {
   const { data } = await supabase
     .from('projects')
-    .select('*, project_transfers(*)')
+    .select('*, project_transfers(id, project_id, recipient_name, transferred, created_at)')
     .eq('creator', userId)
   return (data as FullProject[])?.filter((project) => {
     const numTransfers = project.project_transfers
@@ -402,7 +402,7 @@ export async function getFullSimilarProjects(
   const { data, error } = await supabase
     .from('projects')
     .select(
-      '*, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(*), project_transfers(*), project_votes(*), project_follows(follower_id), causes(title, slug)'
+      '*, profiles!projects_creator_fkey(*), bids(*), txns(*), comments(*), rounds(*), project_transfers(id, project_id, recipient_name, transferred, created_at), project_votes(*), project_follows(follower_id), causes(title, slug)'
     )
     .in('id', projectIds)
     .neq('stage', 'hidden')

--- a/hooks/use-text-editor.ts
+++ b/hooks/use-text-editor.ts
@@ -1,5 +1,5 @@
 'use client'
-import Link from '@tiptap/extension-link'
+import Link, { isAllowedUri } from '@tiptap/extension-link'
 import { mergeAttributes, useEditor } from '@tiptap/react'
 import clsx from 'clsx'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -75,6 +75,17 @@ export const proseClass = (size: 'sm' | 'md' | 'lg') =>
 export const DisplayLink = Link.extend({
   renderHTML({ HTMLAttributes }) {
     delete HTMLAttributes.class // Only use our classes (don't duplicate on paste)
+    // Upstream Link strips disallowed URI schemes (javascript: etc.) in its
+    // renderHTML; overriding it means we must re-apply that check ourselves.
+    if (
+      !this.options.isAllowedUri(HTMLAttributes.href, {
+        defaultValidate: (url: string) => !!isAllowedUri(url, this.options.protocols),
+        protocols: this.options.protocols,
+        defaultProtocol: this.options.defaultProtocol,
+      })
+    ) {
+      HTMLAttributes.href = ''
+    }
     return [
       'a',
       mergeAttributes(HTMLAttributes, {

--- a/pages/api/checkout-sessions.ts
+++ b/pages/api/checkout-sessions.ts
@@ -1,6 +1,8 @@
 import Stripe from 'stripe'
 import { NextApiRequest, NextApiResponse } from 'next'
-import { isProd } from '@/db/env'
+import { createServerClient } from '@supabase/ssr'
+import { Database } from '@/db/database.types'
+import { isProd, SUPABASE_ANON_KEY, SUPABASE_URL } from '@/db/env'
 import { CENTS_PER_DOLLAR } from '@/utils/constants'
 import { stripe } from '@/utils/stripe'
 
@@ -14,41 +16,58 @@ export type StripeSession = Stripe.Event.Data.Object & {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const { dollarQuantity, userId, passFundsToId } = (await req.body) as {
-    dollarQuantity: number
-    userId: string
-    passFundsToId: string
-  }
-  const amountToCharge = dollarQuantity * CENTS_PER_DOLLAR
-  if (req.method === 'POST') {
-    try {
-      const session = await stripe.checkout.sessions.create({
-        metadata: {
-          userId,
-          dollarQuantity,
-          passFundsToId,
-        },
-        line_items: [
-          {
-            price_data: {
-              currency: 'usd',
-              unit_amount: amountToCharge,
-              product: isProd() ? 'prod_NqCUvVOuGcx6jo' : 'prod_NqCWEno6lHiydK',
-            },
-            quantity: 1,
-          },
-        ],
-        mode: 'payment',
-        success_url: isProd() ? 'https://manifund.org' : 'http://localhost:3000',
-        cancel_url: isProd() ? 'https://manifund.org' : 'http://localhost:3000',
-      })
-      res.json({ url: session.url, id: session.id })
-    } catch (error: any) {
-      console.log(error)
-      res.status(error.statusCode || 500).json(error.message)
-    }
-  } else {
+  if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST')
-    res.status(405).end('Method Not Allowed')
+    return res.status(405).end('Method Not Allowed')
+  }
+  // Node-runtime equivalent of getUserAndClient: the deposit is always
+  // credited to the signed-in caller, never to a body-supplied user id.
+  const supabase = createServerClient<Database>(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+    cookies: {
+      getAll() {
+        return Object.entries(req.cookies).map(([name, value]) => ({ name, value: value ?? '' }))
+      },
+      setAll() {},
+    },
+  })
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+  const { dollarQuantity, passFundsToId } = (await req.body) as {
+    dollarQuantity: number
+    passFundsToId?: string
+  }
+  if (!Number.isFinite(dollarQuantity) || dollarQuantity <= 0 || dollarQuantity > 1_000_000) {
+    return res.status(400).json({ error: 'Invalid amount' })
+  }
+  const amountToCharge = Math.round(dollarQuantity * CENTS_PER_DOLLAR)
+  try {
+    const session = await stripe.checkout.sessions.create({
+      metadata: {
+        userId: user.id,
+        dollarQuantity,
+        passFundsToId: passFundsToId ?? null,
+      },
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            unit_amount: amountToCharge,
+            product: isProd() ? 'prod_NqCUvVOuGcx6jo' : 'prod_NqCWEno6lHiydK',
+          },
+          quantity: 1,
+        },
+      ],
+      mode: 'payment',
+      success_url: isProd() ? 'https://manifund.org' : 'http://localhost:3000',
+      cancel_url: isProd() ? 'https://manifund.org' : 'http://localhost:3000',
+    })
+    res.json({ url: session.url, id: session.id })
+  } catch (error: any) {
+    console.log(error)
+    res.status(error.statusCode || 500).json(error.message)
   }
 }

--- a/pages/api/comment-notifications.ts
+++ b/pages/api/comment-notifications.ts
@@ -4,7 +4,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { generateHTML } from '@tiptap/html'
 import { getCommentById } from '@/db/comment'
-import { sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
+import { escapeHtml, sendTemplateEmail, TEMPLATE_IDS } from '@/utils/email'
 import { parseMentions } from '@/utils/parse'
 import { Comment } from '@/db/comment'
 import { JSONContent } from '@tiptap/core'
@@ -70,7 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           await sendTemplateEmail(
             TEMPLATE_IDS.GENERIC_NOTIF_HTML,
             {
-              htmlContent: `<p>The creator of "${fullComment.projects.title}" has posted a progress update on their project:</p><hr />${generateExcerptHtml(comment.content as JSONContent)}`,
+              htmlContent: `<p>The creator of "${escapeHtml(fullComment.projects.title)}" has posted a progress update on their project:</p><hr />${generateExcerptHtml(comment.content as JSONContent)}`,
               buttonUrl: `https://manifund.org/projects/${fullComment.projects.slug}?tab=comments#${comment.id}`,
               buttonText: 'View update',
               subject: `Manifund: Update posted for "${fullComment.projects.title}"`,
@@ -81,7 +81,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           await sendTemplateEmail(
             TEMPLATE_IDS.GENERIC_NOTIF_HTML,
             {
-              htmlContent: `<p>The creator of "${fullComment.projects.title}" has completed their project and posted a final report:</p><hr />${generateExcerptHtml(comment.content as JSONContent)}`,
+              htmlContent: `<p>The creator of "${escapeHtml(fullComment.projects.title)}" has completed their project and posted a final report:</p><hr />${generateExcerptHtml(comment.content as JSONContent)}`,
               buttonUrl: `https://manifund.org/projects/${fullComment.projects.slug}?tab=comments#${comment.id}`,
               buttonText: 'View update',
               subject: `Manifund: Final report posted for "${fullComment.projects.title}"`,

--- a/pages/api/edit-project.ts
+++ b/pages/api/edit-project.ts
@@ -11,6 +11,18 @@ export const config = {
   regions: ['sfo1'],
 }
 
+const CREATOR_EDITABLE_FIELDS = [
+  'title',
+  'blurb',
+  'description',
+  'min_funding',
+  'funding_goal',
+  'founder_shares',
+  'auction_close',
+  'location_description',
+  'lobbying',
+]
+
 export default async function handler(req: NextRequest) {
   const { projectUpdate, projectId, causeSlugs } = (await req.json()) as {
     projectUpdate: ProjectUpdate
@@ -20,10 +32,16 @@ export default async function handler(req: NextRequest) {
   const { supabase: supabaseEdge, user } = await getUserAndClient(req)
   const supabase = isAdmin(user) ? createAdminClient() : supabaseEdge
   if (!user) return NextResponse.error()
+  const update = isAdmin(user)
+    ? { ...projectUpdate }
+    : // Non-admins may only edit the fields the project forms expose
+      (Object.fromEntries(
+        Object.entries(projectUpdate).filter(([key]) => CREATOR_EDITABLE_FIELDS.includes(key))
+      ) as ProjectUpdate)
   // Score columns are server-managed; never accept them from the client
-  delete projectUpdate.ai_fraction
-  delete projectUpdate.quality_score
-  await updateProject(supabase, projectId, projectUpdate)
+  delete update.ai_fraction
+  delete update.quality_score
+  await updateProject(supabase, projectId, update)
   console.log(causeSlugs)
   await updateProjectCauses(supabase, causeSlugs, projectId)
 

--- a/pages/api/place-bid.ts
+++ b/pages/api/place-bid.ts
@@ -26,6 +26,9 @@ export default async function handler(req: NextRequest) {
   if (!user) {
     return new Response('Unauthorized', { status: 401 })
   }
+  if (!Number.isFinite(amount) || amount <= 0 || !Number.isFinite(valuation) || valuation < 0) {
+    return new Response('Invalid amount', { status: 400 })
+  }
   const [bidder, txns, bids, project] = await Promise.all([
     getProfileAndBidsById(supabase, user.id),
     getTxnAndProjectsByUser(supabase, user.id),

--- a/pages/api/publish-project.ts
+++ b/pages/api/publish-project.ts
@@ -21,6 +21,13 @@ export default async function handler(req: NextRequest) {
   }
   const { supabase, user } = await getUserAndClient(req)
   if (!user) return NextResponse.error()
+  const existingProject = await getProjectById(supabase, projectId)
+  if (existingProject.creator !== user.id) {
+    return NextResponse.json({ error: 'Not your project' }, { status: 403 })
+  }
+  if (existingProject.stage !== 'draft') {
+    return NextResponse.json({ error: 'Only draft projects can be published' }, { status: 400 })
+  }
   const causeSlugs = projectParams.selectedCauses.map((cause) => cause.slug)
   const selectedPrize = projectParams.selectedPrize
   const startingStage =

--- a/pages/api/stripe-endpoints.ts
+++ b/pages/api/stripe-endpoints.ts
@@ -45,6 +45,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (event.type === 'checkout.session.completed') {
     const session = event.data.object as Stripe.Checkout.Session
+    // Delayed-notification payment methods fire this event before the money
+    // moves; only credit once Stripe says the session is actually paid.
+    if (session.payment_status !== 'paid') {
+      return res.status(200).send('ignored: not paid')
+    }
     const supabase = createAdminClient()
     const txnId = uuid()
     await issueMoneys(session, txnId, supabase)
@@ -72,7 +77,16 @@ const issueMoneys = async (
 ) => {
   const { id: sessionId } = session
   const { userId, dollarQuantity, passFundsToId } = session.metadata ?? {}
-  const dollarQuantityNum = Number.parseInt(dollarQuantity)
+  // Credit what Stripe actually collected, not what the metadata claims
+  const dollarQuantityNum = (session.amount_total ?? 0) / 100
+  if (dollarQuantityNum <= 0) {
+    throw new Error(`checkout session ${sessionId} completed with amount_total 0`)
+  }
+  if (dollarQuantityNum !== Number.parseFloat(dollarQuantity)) {
+    console.error(
+      `checkout session ${sessionId}: metadata says $${dollarQuantity}, charged $${dollarQuantityNum}`
+    )
+  }
   // TODO: make this an RPC
   await supabase
     .from('txns')

--- a/pages/api/trade-with-amm.ts
+++ b/pages/api/trade-with-amm.ts
@@ -37,6 +37,13 @@ export default async function handler(req: NextRequest) {
   if (!user) {
     return new Response('Unauthorized', { status: 401 })
   }
+  if (
+    !Number.isFinite(amount) ||
+    amount <= 0 ||
+    (valuation !== undefined && (!Number.isFinite(valuation) || valuation <= 0))
+  ) {
+    return new Response('Invalid amount', { status: 400 })
+  }
   const ammTxns = await getTxnsByUser(supabase, projectId)
   const [ammShares, ammUSD] = calculateAMMPorfolio(ammTxns, projectId)
   const numDollars = buying

--- a/pages/api/trade-with-limit.ts
+++ b/pages/api/trade-with-limit.ts
@@ -40,6 +40,16 @@ export default async function handler(req: NextRequest) {
     console.error('no user profile')
     return NextResponse.error()
   }
+  if (
+    !Number.isFinite(numDollarsInTrade) ||
+    numDollarsInTrade <= 0 ||
+    oldBid.status !== 'pending' ||
+    oldBid.bidder === user.id ||
+    oldBid.valuation <= 0
+  ) {
+    console.error('invalid trade parameters')
+    return NextResponse.error()
+  }
   const [partnerTxns, partnerBids] = await Promise.all([
     getTxnAndProjectsByUser(supabase, oldBid.bidder),
     getBidsByUser(supabase, oldBid.bidder),

--- a/pages/api/vote.ts
+++ b/pages/api/vote.ts
@@ -18,6 +18,9 @@ export default async function handler(req: NextRequest) {
   if (!user) {
     return NextResponse.error()
   }
+  if (![-1, 0, 1].includes(newMagnitude)) {
+    return NextResponse.error()
+  }
   const oldVote = await getUserProjectVote(supabase, projectId, user.id)
   if (oldVote) {
     await supabase.from('project_votes').update({ magnitude: newMagnitude }).eq('id', oldVote.id)

--- a/supabase/migrations/20260909000000_tighten_rls_policies.sql
+++ b/supabase/migrations/20260909000000_tighten_rls_policies.sql
@@ -1,0 +1,43 @@
+-- Bids: was WITH CHECK (true) — any authenticated user could insert arbitrary
+-- rows (any bidder, negative amounts) or rewrite their own row into one.
+-- Negative pending bids read as positive spendable balance, so this was a
+-- direct balance-minting hole via the public REST API.
+drop policy "Enable insert for authenticated users only" on public.bids;
+create policy "Users can insert their own bids" on public.bids
+  for insert to authenticated
+  with check (bidder = auth.uid() and amount >= 0 and valuation >= 0);
+
+drop policy "Enable update for users based on user_id" on public.bids;
+create policy "Users can update their own bids" on public.bids
+  for update to authenticated
+  using (bidder = auth.uid())
+  with check (bidder = auth.uid() and amount >= 0);
+
+-- stripe_txns are written only by the Stripe webhook via the service role.
+drop policy "Enable insert for authenticated users only" on public.stripe_txns;
+
+-- project_transfers are created only by the create_transfer_grant RPC and
+-- admin-client scripts; a client-inserted row would let its author claim any
+-- project by signing up with the row's recipient_email. The email column is
+-- also hidden from the public keys (the app selects explicit columns).
+drop policy "Enable insert for authenticated users only" on public.project_transfers;
+revoke select on public.project_transfers from anon, authenticated;
+grant select (id, project_id, recipient_name, transferred, created_at)
+  on public.project_transfers to anon, authenticated;
+
+-- Evals and trust rows: pin inserts to the caller (updates already were).
+drop policy "Enable insert for authenticated users only" on public.project_evals;
+create policy "Users can insert their own evals" on public.project_evals
+  for insert to authenticated
+  with check (evaluator_id = auth.uid());
+
+drop policy "Enable insert for authenticated users only" on public.profile_trust;
+create policy "Users can insert their own trust rows" on public.profile_trust
+  for insert to authenticated
+  with check (truster_id = auth.uid());
+
+-- Former team members' personal Google accounts still had blanket UPDATE on
+-- all projects.
+drop policy "Enable update for rachel based on email" on public.projects;
+drop policy "Enable update for saul based on email" on public.projects;
+drop policy "Enable update for lily based on email" on public.projects;

--- a/supabase/migrations/20260911000000_secure_grant_rpcs.sql
+++ b/supabase/migrations/20260911000000_secure_grant_rpcs.sql
@@ -1,0 +1,87 @@
+-- These RPCs are invoked only via the service role (webhooks, cron), which
+-- bypasses RLS; ordinary users must not be able to call them through
+-- PostgREST at all.
+do $$
+declare fn record;
+begin
+  for fn in
+    select oid::regprocedure as sig from pg_proc
+    where pronamespace = 'public'::regnamespace
+      and proname in ('_transfer_project', 'activate_grant', 'activate_cert', 'reject_proposal')
+  loop
+    execute format('revoke execute on function %s from public, anon, authenticated', fn.sig);
+  end loop;
+end $$;
+
+-- create_transfer_grant is called with the regranter's own client, and its
+-- project_transfers insert stops passing RLS once the open INSERT policy is
+-- dropped (20260909000000). It becomes SECURITY DEFINER with explicit caller
+-- checks instead of relying on caller RLS. Body otherwise unchanged.
+create or replace function public.create_transfer_grant(project project_row, donor_comment comment_row, project_transfer transfer_row, grant_amount numeric)
+ returns void
+ language plpgsql
+ security definer
+ set search_path = public
+as $function$
+BEGIN
+  IF auth.uid() IS NULL
+     OR project.creator IS DISTINCT FROM auth.uid()
+     OR donor_comment.commenter IS DISTINCT FROM auth.uid()
+     OR grant_amount IS NULL
+     OR grant_amount < 0 THEN
+    RAISE EXCEPTION 'create_transfer_grant: caller mismatch or invalid amount';
+  END IF;
+
+  INSERT INTO projects (id, creator, title, blurb, description, min_funding, funding_goal, founder_shares, type, stage, round, slug, approved, signed_agreement, location_description, lobbying)
+  VALUES (project.id, project.creator, project.title, project.blurb, project.description, project.min_funding, project.funding_goal, project.founder_shares, project.type, project.stage, project.round, project.slug, null, false, project.location_description, project.lobbying);
+
+  INSERT INTO comments (id, project, commenter, content)
+  VALUES (donor_comment.id, donor_comment.project, donor_comment.commenter, donor_comment.content);
+
+  INSERT INTO project_transfers(recipient_email, recipient_name, project_id)
+  VALUES (project_transfer.recipient_email, project_transfer.recipient_name, project_transfer.project_id);
+
+  INSERT INTO bids (project, amount, bidder, type, valuation)
+  VALUES (project.id, grant_amount, project.creator, 'donate', 0);
+
+  EXECUTE(follow_project(project.id, project.creator));
+END;
+$function$;
+
+-- give_grant creates the project with creator = the grant RECIPIENT, so it
+-- cannot pass a creator-pinned projects INSERT policy as invoker; it becomes
+-- SECURITY DEFINER with the caller pinned to the donation/comment instead.
+-- (project.creator is intentionally unchecked: it names the recipient.)
+create or replace function public.give_grant(project project_row, donor_comment comment_row, donation bid_row)
+ returns void
+ language plpgsql
+ security definer
+ set search_path = public
+as $function$
+BEGIN
+  IF auth.uid() IS NULL
+     OR donation.bidder IS DISTINCT FROM auth.uid()
+     OR donor_comment.commenter IS DISTINCT FROM auth.uid()
+     OR donation.amount IS NULL
+     OR donation.amount < 0 THEN
+    RAISE EXCEPTION 'give_grant: caller mismatch or invalid amount';
+  END IF;
+
+  INSERT INTO projects (id, creator, title, blurb, description, min_funding, funding_goal, founder_shares, type, stage, round, slug, approved, signed_agreement, location_description, lobbying)
+  VALUES (project.id, project.creator, project.title, project.blurb, project.description, project.min_funding, project.funding_goal, project.founder_shares, project.type, project.stage, project.round, project.slug, null, false, project.location_description, project.lobbying);
+
+  INSERT INTO bids (project, amount, bidder, type, valuation)
+  VALUES (donation.project, donation.amount, donation.bidder, 'donate', 0);
+
+  INSERT INTO comments (id, project, commenter, content)
+  VALUES (donor_comment.id, donor_comment.project, donor_comment.commenter, donor_comment.content);
+
+  EXECUTE(follow_project(project.id, donor_comment.commenter));
+END;$function$;
+
+-- Anyone authenticated could insert projects with an arbitrary creator id;
+-- every legitimate flow inserts creator = the caller.
+drop policy "Enable insert for authenticated users only" on public.projects;
+create policy "Users can insert their own projects" on public.projects
+  for insert to authenticated
+  with check (creator = auth.uid());


### PR DESCRIPTION
Amount validation on bid/trade routes, ownership+stage check on publish-project, column allowlist on edit-project, authed checkout-sessions with paid-status/amount verification in the webhook, Tiptap attr sanitization, link-scheme check restored, escaped email titles, safeNext on the OAuth handler, vote clamp, plus an RLS-tightening migration (apply after this deploys — see migration file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rxHEWF5rCw7Gvk9cmoBGg